### PR TITLE
fix/build: Links to BLAS by default on macOS instead of openblas

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,13 @@ extern crate pkg_config;
 use std::env;
 
 fn main() {
-    let variant = env::var("BLAS_VARIANT").unwrap_or("openblas".to_string());
+    let variant = env::var("BLAS_VARIANT").unwrap_or_else(|_| {
+        if let Ok("x86_64-apple-darwin") = std::env::var("TARGET").as_ref().map(|s| &s[..]) {
+            "BLAS".to_string()
+        } else {
+            "openblas".to_string()
+        }
+    });
     let lib_dir = env::var("BLAS_LIB_DIR").ok();
     let include_dir = env::var("BLAS_INCLUDE_DIR").ok();
 


### PR DESCRIPTION
Links to BLAS by default as it comes bundled with macOS in the Accelerate System Framework. 

If the user wishes to use openblas, setting `BLAS_LIB_DIR` to `/usr/local/opt/openblas/lib` (path specific to homebrew) should be enough, as openblas already symlinks `libblas.dylib` to `libopenblas.dylib`.

Also fixes spearow/juice#53 and all tests pass