### PR TITLE
Fix warnings

### DIFF
--- a/examples/math.rs
+++ b/examples/math.rs
@@ -6,9 +6,9 @@ use blas::math::Marker::T;
 
 fn main() {
     let x = vec![1.0, 2.0];
-    let xr = &x as &Vector<_>;
+    let xr = &x as &dyn Vector<_>;
     let i = mat![1.0, 0.0; 0.0, 1.0];
-    let ir = &i as &Matrix<_>;
+    let ir = &i as &dyn Matrix<_>;
 
     assert!(xr + &x == 2.0 * xr);
     assert!(ir * xr == x);

--- a/src/math/mat.rs
+++ b/src/math/mat.rs
@@ -105,10 +105,10 @@ impl<T> Matrix<T> for Mat<T> {
     }
 }
 
-impl<'a, T> From<&'a Matrix<T>> for Mat<T>
+impl<'a, T> From<&'a dyn Matrix<T>> for Mat<T>
     where T: Copy
 {
-    fn from(a: &Matrix<T>) -> Mat<T> {
+    fn from(a: &dyn Matrix<T>) -> Mat<T> {
         let n = a.rows() as usize;
         let m = a.cols() as usize;
         let len = n * m;

--- a/src/math/mat.rs
+++ b/src/math/mat.rs
@@ -9,7 +9,6 @@ use std::ops::Index;
 use std::slice;
 use num::traits::NumCast;
 use Matrix;
-use Vector;
 use vector::ops::Copy;
 
 #[derive(Debug, PartialEq)]

--- a/src/math/matrix_vector.rs
+++ b/src/math/matrix_vector.rs
@@ -13,12 +13,12 @@ use matrix::Matrix;
 use math::Trans;
 use math::Mat;
 
-impl<'a, T> Mul<&'a Vector<T>> for &'a Matrix<T>
+impl<'a, T> Mul<&'a dyn Vector<T>> for &'a dyn Matrix<T>
     where T: Default + Copy + Gemv
 {
     type Output = Vec<T>;
 
-    fn mul(self, x: &Vector<T>) -> Vec<T> {
+    fn mul(self, x: &dyn Vector<T>) -> Vec<T> {
         let n = self.rows() as usize;
         let mut result = Vec::with_capacity(n);
         unsafe { result.set_len(n); }
@@ -31,12 +31,12 @@ impl<'a, T> Mul<&'a Vector<T>> for &'a Matrix<T>
     }
 }
 
-impl<'a, T> Mul<Trans<&'a Vector<T>>> for &'a Vector<T>
+impl<'a, T> Mul<Trans<&'a dyn Vector<T>>> for &'a dyn Vector<T>
     where T: Default + Ger + Gerc + Clone,
 {
     type Output = Mat<T>;
 
-    fn mul(self, x: Trans<&Vector<T>>) -> Mat<T> {
+    fn mul(self, x: Trans<&dyn Vector<T>>) -> Mat<T> {
         let n = self.len() as usize;
         let m = (*x).len() as usize;
         let mut result = Mat::fill(Default::zero(), n, m);
@@ -64,8 +64,8 @@ mod tests {
         let x = vec![2f32, 1.0];
 
         let y = {
-            let ar = &a as &Matrix<f32>;
-            let xr = &x as &Vector<f32>;
+            let ar = &a as &dyn Matrix<f32>;
+            let xr = &x as &dyn Vector<f32>;
             ar * xr
         };
 
@@ -78,8 +78,8 @@ mod tests {
         let y = vec![3.0, 6.0, -1.0];
 
         let a = {
-            let xr = &x as &Vector<_>;
-            let yr = &y as &Vector<_>;
+            let xr = &x as &dyn Vector<_>;
+            let yr = &y as &dyn Vector<_>;
 
             xr * (yr ^ T)
         };

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -37,11 +37,11 @@ pub enum Marker {
     H,
 }
 
-impl<'a, T> BitXor<Marker> for &'a Vector<T>
+impl<'a, T> BitXor<Marker> for &'a dyn Vector<T>
 {
-    type Output = Trans<&'a Vector<T>>;
+    type Output = Trans<&'a dyn Vector<T>>;
 
-    fn bitxor(self, m: Marker) -> Trans<&'a Vector<T>> {
+    fn bitxor(self, m: Marker) -> Trans<&'a dyn Vector<T>> {
         match m {
             Marker::T => Trans::T(self),
             Marker::H => Trans::H(self),
@@ -49,11 +49,11 @@ impl<'a, T> BitXor<Marker> for &'a Vector<T>
     }
 }
 
-impl<'a, T> BitXor<Marker> for &'a Matrix<T>
+impl<'a, T> BitXor<Marker> for &'a dyn Matrix<T>
 {
-    type Output = Trans<&'a Matrix<T>>;
+    type Output = Trans<&'a dyn Matrix<T>>;
 
-    fn bitxor(self, m: Marker) -> Trans<&'a Matrix<T>> {
+    fn bitxor(self, m: Marker) -> Trans<&'a dyn Matrix<T>> {
         match m {
             Marker::T => Trans::T(self),
             Marker::H => Trans::H(self),

--- a/src/math/vector.rs
+++ b/src/math/vector.rs
@@ -12,12 +12,12 @@ use vector::ops::*;
 use vector::Vector;
 use math::Trans;
 
-impl<'a, T> Add for &'a Vector<T>
+impl<'a, T> Add for &'a dyn Vector<T>
     where T: Axpy + Copy + Default
 {
     type Output = Vec<T>;
 
-    fn add(self, x: &Vector<T>) -> Vec<T> {
+    fn add(self, x: &dyn Vector<T>) -> Vec<T> {
         let mut result: Vec<_> = self.into();
         let scale = Default::one();
 
@@ -26,12 +26,12 @@ impl<'a, T> Add for &'a Vector<T>
     }
 }
 
-impl<'a, T> Mul<&'a Vector<T>> for Trans<&'a Vector<T>>
+impl<'a, T> Mul<&'a dyn Vector<T>> for Trans<&'a dyn Vector<T>>
     where T: Sized + Copy + Dot + Dotc
 {
     type Output = T;
 
-    fn mul(self, x: &Vector<T>) -> T {
+    fn mul(self, x: &dyn Vector<T>) -> T {
         match self {
             Trans::T(v) => Dot::dot(v, x),
             Trans::H(v) => Dotc::dotc(v, x),
@@ -39,7 +39,7 @@ impl<'a, T> Mul<&'a Vector<T>> for Trans<&'a Vector<T>>
     }
 }
 
-impl<'a, T> Mul<T> for &'a Vector<T>
+impl<'a, T> Mul<T> for &'a dyn Vector<T>
     where T: Sized + Copy + Scal
 {
     type Output = Vec<T>;
@@ -53,11 +53,11 @@ impl<'a, T> Mul<T> for &'a Vector<T>
 
 macro_rules! left_scale(($($t: ident), +) => (
     $(
-        impl<'a> Mul<&'a Vector<$t>> for $t
+        impl<'a> Mul<&'a dyn Vector<$t>> for $t
         {
             type Output = Vec<$t>;
 
-            fn mul(self, x: &Vector<$t>) -> Vec<$t> {
+            fn mul(self, x: &dyn Vector<$t>) -> Vec<$t> {
                 let mut result: Vec<_> = x.into();
                 Scal::scal(&self, &mut result);
                 result
@@ -79,7 +79,7 @@ mod tests {
         let x = vec![1f32, 2f32];
         let y = vec![3f32, 4f32];
 
-        let z = &x as &Vector<_> + &y;
+        let z = (&x as &dyn Vector<_>) + &y;
 
         assert_eq!(&z, &vec![4f32, 6f32]);
     }
@@ -90,7 +90,7 @@ mod tests {
         let y = vec![-1f32, 2f32];
 
         let dot = {
-            let z = &x as &Vector<_>;
+            let z = &x as &dyn Vector<_>;
             (z ^ T) * &y
         };
 
@@ -103,7 +103,7 @@ mod tests {
         let y = vec![Complex::new(1f32, 2f32), Complex::new(1f32, 3f32)];
 
         let dot = {
-            let z = &x as &Vector<_>;
+            let z = &x as &dyn Vector<_>;
             (z ^ H) * &y
         };
 
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn scale() {
         let x = vec![1f32, 2f32];
-        let xr = &x as &Vector<_>;
+        let xr = &x as &dyn Vector<_>;
 
         let y = xr * 3.0;
         let z = 3.0 * xr;

--- a/src/matrix/ops.rs
+++ b/src/matrix/ops.rs
@@ -10,7 +10,6 @@ use pointer::CPtr;
 use scalar::Scalar;
 use matrix::ll::*;
 use matrix::Matrix;
-use vector::Vector;
 
 pub trait Gemm: Sized {
     fn gemm(alpha: &Self, at: Transpose, a: &dyn Matrix<Self>, bt: Transpose, b: &dyn Matrix<Self>, beta: &Self, c: &mut dyn Matrix<Self>);

--- a/src/matrix/ops.rs
+++ b/src/matrix/ops.rs
@@ -13,13 +13,13 @@ use matrix::Matrix;
 use vector::Vector;
 
 pub trait Gemm: Sized {
-    fn gemm(alpha: &Self, at: Transpose, a: &Matrix<Self>, bt: Transpose, b: &Matrix<Self>, beta: &Self, c: &mut Matrix<Self>);
+    fn gemm(alpha: &Self, at: Transpose, a: &dyn Matrix<Self>, bt: Transpose, b: &dyn Matrix<Self>, beta: &Self, c: &mut dyn Matrix<Self>);
 }
 
 macro_rules! gemm_impl(($($t: ident), +) => (
     $(
         impl Gemm for $t {
-            fn gemm(alpha: &$t, at: Transpose, a: &Matrix<$t>, bt: Transpose, b: &Matrix<$t>, beta: &$t, c: &mut Matrix<$t>) {
+            fn gemm(alpha: &$t, at: Transpose, a: &dyn Matrix<$t>, bt: Transpose, b: &dyn Matrix<$t>, beta: &$t, c: &mut dyn Matrix<$t>) {
                 unsafe {
                     let (m, k)  = match at {
                         Transpose::NoTrans => (a.rows(), a.cols()),
@@ -85,17 +85,17 @@ mod gemm_tests {
 }
 
 pub trait Symm: Sized {
-    fn symm(side: Side, symmetry: Symmetry, alpha: &Self, a: &Matrix<Self>, b: &Matrix<Self>, beta: &Self, c: &mut Matrix<Self>);
+    fn symm(side: Side, symmetry: Symmetry, alpha: &Self, a: &dyn Matrix<Self>, b: &dyn Matrix<Self>, beta: &Self, c: &mut dyn Matrix<Self>);
 }
 
 pub trait Hemm: Sized {
-    fn hemm(side: Side, symmetry: Symmetry, alpha: &Self, a: &Matrix<Self>, b: &Matrix<Self>, beta: &Self, c: &mut Matrix<Self>);
+    fn hemm(side: Side, symmetry: Symmetry, alpha: &Self, a: &dyn Matrix<Self>, b: &dyn Matrix<Self>, beta: &Self, c: &mut dyn Matrix<Self>);
 }
 
 macro_rules! symm_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
     $(
         impl $trait_name for $t {
-            fn $fn_name(side: Side, symmetry: Symmetry, alpha: &$t, a: &Matrix<$t>, b: &Matrix<$t>, beta: &$t, c: &mut Matrix<$t>) {
+            fn $fn_name(side: Side, symmetry: Symmetry, alpha: &$t, a: &dyn Matrix<$t>, b: &dyn Matrix<$t>, beta: &$t, c: &mut dyn Matrix<$t>) {
                 unsafe {
                     prefix!($t, $fn_name)(a.order(),
                         side, symmetry,
@@ -115,17 +115,17 @@ symm_impl!(Symm, symm, f32, f64, Complex32, Complex64);
 symm_impl!(Hemm, hemm, Complex32, Complex64);
 
 pub trait Trmm: Sized {
-    fn trmm(side: Side, symmetry: Symmetry, trans: Transpose, diag: Diagonal, alpha: &Self, a: &Matrix<Self>, b: &mut Matrix<Self>);
+    fn trmm(side: Side, symmetry: Symmetry, trans: Transpose, diag: Diagonal, alpha: &Self, a: &dyn Matrix<Self>, b: &mut dyn Matrix<Self>);
 }
 
 pub trait Trsm: Sized {
-    fn trsm(side: Side, symmetry: Symmetry, trans: Transpose, diag: Diagonal, alpha: &Self, a: &Matrix<Self>, b: &mut Matrix<Self>);
+    fn trsm(side: Side, symmetry: Symmetry, trans: Transpose, diag: Diagonal, alpha: &Self, a: &dyn Matrix<Self>, b: &mut dyn Matrix<Self>);
 }
 
 macro_rules! trmm_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
     $(
         impl $trait_name for $t {
-            fn $fn_name(side: Side, symmetry: Symmetry, trans: Transpose, diag: Diagonal, alpha: &$t, a: &Matrix<$t>, b: &mut Matrix<$t>) {
+            fn $fn_name(side: Side, symmetry: Symmetry, trans: Transpose, diag: Diagonal, alpha: &$t, a: &dyn Matrix<$t>, b: &mut dyn Matrix<$t>) {
                 unsafe {
                     prefix!($t, $fn_name)(a.order(),
                         side, symmetry, trans, diag,
@@ -143,17 +143,17 @@ trmm_impl!(Trmm, trmm, f32, f64, Complex32, Complex64);
 trmm_impl!(Trsm, trsm, Complex32, Complex64);
 
 pub trait Herk: Sized {
-    fn herk(symmetry: Symmetry, trans: Transpose, alpha: &Self, a: &Matrix<Complex<Self>>, beta: &Self, c: &mut Matrix<Complex<Self>>);
+    fn herk(symmetry: Symmetry, trans: Transpose, alpha: &Self, a: &dyn Matrix<Complex<Self>>, beta: &Self, c: &mut dyn Matrix<Complex<Self>>);
 }
 
 pub trait Her2k: Sized {
-    fn her2k(symmetry: Symmetry, trans: Transpose, alpha: Complex<Self>, a: &Matrix<Complex<Self>>, b: &Matrix<Complex<Self>>, beta: &Self, c: &mut Matrix<Complex<Self>>);
+    fn her2k(symmetry: Symmetry, trans: Transpose, alpha: Complex<Self>, a: &dyn Matrix<Complex<Self>>, b: &dyn Matrix<Complex<Self>>, beta: &Self, c: &mut dyn Matrix<Complex<Self>>);
 }
 
 macro_rules! herk_impl(($($t: ident), +) => (
     $(
         impl Herk for $t {
-            fn herk(symmetry: Symmetry, trans: Transpose, alpha: &$t, a: &Matrix<Complex<$t>>, beta: &$t, c: &mut Matrix<Complex<$t>>) {
+            fn herk(symmetry: Symmetry, trans: Transpose, alpha: &$t, a: &dyn Matrix<Complex<$t>>, beta: &$t, c: &mut dyn Matrix<Complex<$t>>) {
                 unsafe {
                     prefix!(Complex<$t>, herk)(a.order(),
                         symmetry, trans,
@@ -167,7 +167,7 @@ macro_rules! herk_impl(($($t: ident), +) => (
         }
 
         impl Her2k for $t {
-            fn her2k(symmetry: Symmetry, trans: Transpose, alpha: Complex<$t>, a: &Matrix<Complex<$t>>, b: &Matrix<Complex<$t>>, beta: &$t, c: &mut Matrix<Complex<$t>>) {
+            fn her2k(symmetry: Symmetry, trans: Transpose, alpha: Complex<$t>, a: &dyn Matrix<Complex<$t>>, b: &dyn Matrix<Complex<$t>>, beta: &$t, c: &mut dyn Matrix<Complex<$t>>) {
                 unsafe {
                     prefix!(Complex<$t>, her2k)(a.order(),
                         symmetry, trans,
@@ -186,17 +186,17 @@ macro_rules! herk_impl(($($t: ident), +) => (
 herk_impl!(f32, f64);
 
 pub trait Syrk: Sized {
-    fn syrk(symmetry: Symmetry, trans: Transpose, alpha: &Self, a: &Matrix<Self>, beta: &Self, c: &mut Matrix<Self>);
+    fn syrk(symmetry: Symmetry, trans: Transpose, alpha: &Self, a: &dyn Matrix<Self>, beta: &Self, c: &mut dyn Matrix<Self>);
 }
 
 pub trait Syr2k: Sized {
-    fn syr2k(symmetry: Symmetry, trans: Transpose, alpha: &Self, a: &Matrix<Self>, b: &Matrix<Self>, beta: &Self, c: &mut Matrix<Self>);
+    fn syr2k(symmetry: Symmetry, trans: Transpose, alpha: &Self, a: &dyn Matrix<Self>, b: &dyn Matrix<Self>, beta: &Self, c: &mut dyn Matrix<Self>);
 }
 
 macro_rules! syrk_impl(($($t: ident), +) => (
     $(
         impl Syrk for $t {
-            fn syrk(symmetry: Symmetry, trans: Transpose, alpha: &$t, a: &Matrix<$t>, beta: &$t, c: &mut Matrix<$t>) {
+            fn syrk(symmetry: Symmetry, trans: Transpose, alpha: &$t, a: &dyn Matrix<$t>, beta: &$t, c: &mut dyn Matrix<$t>) {
                 unsafe {
                     prefix!($t, syrk)(a.order(),
                         symmetry, trans,
@@ -210,7 +210,7 @@ macro_rules! syrk_impl(($($t: ident), +) => (
         }
 
         impl Syr2k for $t {
-            fn syr2k(symmetry: Symmetry, trans: Transpose, alpha: &$t, a: &Matrix<$t>, b: &Matrix<$t>, beta: &$t, c: &mut Matrix<$t>) {
+            fn syr2k(symmetry: Symmetry, trans: Transpose, alpha: &$t, a: &dyn Matrix<$t>, b: &dyn Matrix<$t>, beta: &$t, c: &mut dyn Matrix<$t>) {
                 unsafe {
                     prefix!($t, syr2k)(a.order(),
                         symmetry, trans,

--- a/src/matrix_vector/ops.rs
+++ b/src/matrix_vector/ops.rs
@@ -16,13 +16,13 @@ use vector::Vector;
 ///
 /// A ← αA<sup>OP</sup>x + βy
 pub trait Gemv: Sized {
-    fn gemv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(trans: Transpose, alpha: &Self, a: &Matrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn gemv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(trans: Transpose, alpha: &Self, a: &dyn Matrix<Self>, x: &V, beta: &Self, y: &mut W);
 }
 
 macro_rules! gemv_impl(($($t: ident), +) => (
     $(
         impl Gemv for $t {
-            fn gemv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(trans: Transpose, alpha: &$t, a: &Matrix<$t>, x: &V, beta: &$t, y: &mut W){
+            fn gemv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(trans: Transpose, alpha: &$t, a: &dyn Matrix<$t>, x: &V, beta: &$t, y: &mut W){
                 unsafe {
                     prefix!($t, gemv)(a.order(), trans,
                         a.rows(), a.cols(),
@@ -93,20 +93,20 @@ mod gemv_tests {
 ///
 /// A ← αAx + βy
 pub trait Symv: Sized {
-    fn symv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &Matrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn symv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &dyn Matrix<Self>, x: &V, beta: &Self, y: &mut W);
 }
 
 /// Hermitian multiply with vector
 ///
 /// A ← αAx + βy
 pub trait Hemv: Sized {
-    fn hemv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &Matrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn hemv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &dyn Matrix<Self>, x: &V, beta: &Self, y: &mut W);
 }
 
 macro_rules! symv_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
     $(
         impl $trait_name for $t {
-            fn $fn_name<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, a: &Matrix<$t>, x: &V, beta: &$t, y: &mut W){
+            fn $fn_name<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, a: &dyn Matrix<$t>, x: &V, beta: &$t, y: &mut W){
                 unsafe {
                     prefix!($t, $fn_name)(a.order(), symmetry,
                         a.rows(),
@@ -171,14 +171,14 @@ mod symv_tests {
 ///
 /// A ← A + αxy<sup>T</sup>
 pub trait Ger: Sized {
-    fn ger<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(alpha: &Self, x: &V, y: &W, a: &mut Matrix<Self>);
+    fn ger<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(alpha: &Self, x: &V, y: &W, a: &mut dyn Matrix<Self>);
 }
 
 /// General rank-1 update (using hermitian conjugate)
 ///
 /// A ← A + αxy<sup>H</sup>
 pub trait Gerc: Ger {
-    fn gerc<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(alpha: &Self, x: &V, y: &W, a: &mut Matrix<Self>) {
+    fn gerc<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(alpha: &Self, x: &V, y: &W, a: &mut dyn Matrix<Self>) {
         Ger::ger(alpha, x, y, a);
     }
 }
@@ -186,7 +186,7 @@ pub trait Gerc: Ger {
 macro_rules! ger_impl(
     ($trait_name: ident, $fn_name: ident, $t: ty, $ger_fn: expr) => (
         impl $trait_name for $t {
-            fn $fn_name<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(alpha: &$t, x: &V, y: &W, a: &mut Matrix<$t>) {
+            fn $fn_name<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(alpha: &$t, x: &V, y: &W, a: &mut dyn Matrix<$t>) {
                 unsafe {
                     $ger_fn(a.order(),
                         a.rows(), a.cols(),
@@ -233,20 +233,20 @@ mod ger_tests {
 ///
 /// A ← A + αxx<sup>T</sup>
 pub trait Syr: Sized {
-    fn syr<V: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, a: &mut Matrix<Self>);
+    fn syr<V: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, a: &mut dyn Matrix<Self>);
 }
 
 /// Hermitian rank-1 update
 ///
 /// A ← A + αxx<sup>H</sup>
 pub trait Her: Sized {
-    fn her<V: ?Sized + Vector<Complex<Self>>>(symmetry: Symmetry, alpha: &Self, x: &V, a: &mut Matrix<Complex<Self>>);
+    fn her<V: ?Sized + Vector<Complex<Self>>>(symmetry: Symmetry, alpha: &Self, x: &V, a: &mut dyn Matrix<Complex<Self>>);
 }
 
 macro_rules! her_impl(($($t: ident), +) => (
     $(
         impl Her for $t {
-            fn her<V: ?Sized + Vector<Complex<Self>>>(symmetry: Symmetry, alpha: &$t, x: &V, a: &mut Matrix<Complex<$t>>) {
+            fn her<V: ?Sized + Vector<Complex<Self>>>(symmetry: Symmetry, alpha: &$t, x: &V, a: &mut dyn Matrix<Complex<$t>>) {
                 unsafe {
                     prefix!(Complex<$t>, her)(a.order(), symmetry,
                         a.rows(),
@@ -264,7 +264,7 @@ her_impl!(f32, f64);
 macro_rules! syr_impl(($($t: ident), +) => (
     $(
         impl Syr for $t {
-            fn syr<V: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, x: &V, a: &mut Matrix<$t>) {
+            fn syr<V: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, x: &V, a: &mut dyn Matrix<$t>) {
                 unsafe {
                     prefix!($t, syr)(a.order(), symmetry,
                         a.rows(),
@@ -283,20 +283,20 @@ syr_impl!(f32, f64);
 ///
 /// A ← A + αxy<sup>T</sup> + αyx<sup>T</sup>
 pub trait Syr2: Sized {
-    fn syr2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, y: &W, a: &mut Matrix<Self>);
+    fn syr2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, y: &W, a: &mut dyn Matrix<Self>);
 }
 
 /// Hermitian rank-2 update
 ///
 /// A ← A + αxy<sup>H</sup> + y(αx)<sup>H</sup>
 pub trait Her2: Sized {
-    fn her2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, y: &W, a: &mut Matrix<Self>);
+    fn her2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, y: &W, a: &mut dyn Matrix<Self>);
 }
 
 macro_rules! syr2_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
     $(
         impl $trait_name for $t {
-            fn $fn_name<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, x: &V, y: &W, a: &mut Matrix<$t>) {
+            fn $fn_name<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, x: &V, y: &W, a: &mut dyn Matrix<$t>) {
                 unsafe {
                     prefix!($t, $fn_name)(a.order(), symmetry,
                         a.rows(),
@@ -317,13 +317,13 @@ syr2_impl!(Her2, her2, Complex32, Complex64);
 ///
 /// A ← αA<sup>OP</sup>x + βy
 pub trait Gbmv: Sized {
-    fn gbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(trans: Transpose, alpha: &Self, a: &BandMatrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn gbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(trans: Transpose, alpha: &Self, a: &dyn BandMatrix<Self>, x: &V, beta: &Self, y: &mut W);
 }
 
 macro_rules! gbmv_impl(($($t: ident), +) => (
     $(
         impl Gbmv for $t {
-            fn gbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(trans: Transpose, alpha: &$t, a: &BandMatrix<$t>, x: &V, beta: &$t, y: &mut W){
+            fn gbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(trans: Transpose, alpha: &$t, a: &dyn BandMatrix<$t>, x: &V, beta: &$t, y: &mut W){
                 unsafe {
                     prefix!($t, gbmv)(a.order(), trans,
                         a.rows(), a.cols(),
@@ -345,20 +345,20 @@ gbmv_impl!(f32, f64, Complex32, Complex64);
 ///
 /// A ← αAx + βy
 pub trait Sbmv: Sized {
-    fn sbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &BandMatrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn sbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &dyn BandMatrix<Self>, x: &V, beta: &Self, y: &mut W);
 }
 
 /// Hermitian band matrix multiply with vector
 ///
 /// A ← αAx + βy
 pub trait Hbmv: Sized {
-    fn hbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &BandMatrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn hbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &dyn BandMatrix<Self>, x: &V, beta: &Self, y: &mut W);
 }
 
 macro_rules! sbmv_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
     $(
         impl $trait_name for $t {
-            fn $fn_name<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, a: &BandMatrix<$t>, x: &V, beta: &$t, y: &mut W) {
+            fn $fn_name<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, a: &dyn BandMatrix<$t>, x: &V, beta: &$t, y: &mut W) {
                 unsafe {
                     prefix!($t, $fn_name)(a.order(), symmetry,
                         a.rows(), a.sub_diagonals(),
@@ -380,20 +380,20 @@ sbmv_impl!(Hbmv, hbmv, Complex32, Complex64);
 ///
 /// A ← A<sup>OP</sup>x
 pub trait Tbmv: Sized {
-    fn tbmv<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &BandMatrix<Self>, x: &mut V);
+    fn tbmv<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &dyn BandMatrix<Self>, x: &mut V);
 }
 
 /// Solve triangular band matrix system
 ///
 /// A ← A<sup>-1 OP</sup>x
 pub trait Tbsv: Sized {
-    fn tbsv<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &BandMatrix<Self>, x: &mut V);
+    fn tbsv<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &dyn BandMatrix<Self>, x: &mut V);
 }
 
 macro_rules! tbmv_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
     $(
         impl $trait_name for $t {
-            fn $fn_name<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &BandMatrix<$t>, x: &mut V) {
+            fn $fn_name<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &dyn BandMatrix<$t>, x: &mut V) {
                 unsafe {
                     prefix!($t, $fn_name)(a.order(), symmetry,
                         trans, diagonal,
@@ -413,20 +413,20 @@ tbmv_impl!(Tbsv, tbsv, f32, f64, Complex32, Complex64);
 ///
 /// A ← αAx + βy
 pub trait Spmv: Sized {
-    fn spmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &Matrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn spmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &dyn Matrix<Self>, x: &V, beta: &Self, y: &mut W);
 }
 
 /// Hermitian packed matrix multiply with vector
 ///
 /// A ← αAx + βy
 pub trait Hpmv: Sized {
-    fn hpmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &Matrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn hpmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &dyn Matrix<Self>, x: &V, beta: &Self, y: &mut W);
 }
 
 macro_rules! spmv_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
     $(
         impl $trait_name for $t {
-            fn $fn_name<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, a: &Matrix<$t>, x: &V, beta: &$t, y: &mut W) {
+            fn $fn_name<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, a: &dyn Matrix<$t>, x: &V, beta: &$t, y: &mut W) {
                 unsafe {
                     prefix!($t, $fn_name)(a.order(), symmetry,
                         a.rows(),
@@ -448,20 +448,20 @@ spmv_impl!(Hpmv, hpmv, Complex32, Complex64);
 ///
 /// A ← A<sup>OP</sup>x
 pub trait Tpmv: Sized {
-    fn tpmv<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &Matrix<Self>, x: &mut V);
+    fn tpmv<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &dyn Matrix<Self>, x: &mut V);
 }
 
 /// Solve triangular packed matrix system
 ///
 /// A ← A<sup>-1 OP</sup>x
 pub trait Tpsv: Sized {
-    fn tpsv<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &Matrix<Self>, x: &mut V);
+    fn tpsv<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &dyn Matrix<Self>, x: &mut V);
 }
 
 macro_rules! tpmv_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
     $(
         impl $trait_name for $t {
-            fn $fn_name<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &Matrix<$t>, x: &mut V) {
+            fn $fn_name<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &dyn Matrix<$t>, x: &mut V) {
                 unsafe {
                     prefix!($t, $fn_name)(a.order(), symmetry,
                         trans, diagonal,
@@ -481,13 +481,13 @@ tpmv_impl!(Tpsv, tpsv, f32, f64, Complex32, Complex64);
 ///
 /// A ← A + αxx<sup>H</sup>
 pub trait Hpr: Sized {
-    fn hpr<V: ?Sized + Vector<Complex<Self>>>(symmetry: Symmetry, alpha: &Self, x: &V, a: &mut Matrix<Complex<Self>>);
+    fn hpr<V: ?Sized + Vector<Complex<Self>>>(symmetry: Symmetry, alpha: &Self, x: &V, a: &mut dyn Matrix<Complex<Self>>);
 }
 
 macro_rules! hpr_impl(($($t: ident), +) => (
     $(
         impl Hpr for $t {
-            fn hpr<V: ?Sized + Vector<Complex<Self>>>(symmetry: Symmetry, alpha: &$t, x: &V, a: &mut Matrix<Complex<$t>>) {
+            fn hpr<V: ?Sized + Vector<Complex<Self>>>(symmetry: Symmetry, alpha: &$t, x: &V, a: &mut dyn Matrix<Complex<$t>>) {
                 unsafe {
                     prefix!(Complex<$t>, hpr)(a.order(), symmetry,
                         a.rows(),
@@ -506,13 +506,13 @@ hpr_impl!(f32, f64);
 ///
 /// A ← A + αxx<sup>T</sup>
 pub trait Spr: Sized {
-    fn spr<V: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, a: &mut Matrix<Self>);
+    fn spr<V: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, a: &mut dyn Matrix<Self>);
 }
 
 macro_rules! spr_impl(($($t: ident), +) => (
     $(
         impl Spr for $t {
-            fn spr<V: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, x: &V, a: &mut Matrix<$t>) {
+            fn spr<V: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, x: &V, a: &mut dyn Matrix<$t>) {
                 unsafe {
                     prefix!($t, spr)(a.order(), symmetry,
                         a.rows(),
@@ -531,20 +531,20 @@ spr_impl!(f32, f64);
 ///
 /// A ← A + αxy<sup>T</sup> + αyx<sup>T</sup>
 pub trait Spr2: Sized {
-    fn spr2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, y: &W, a: &mut Matrix<Self>);
+    fn spr2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, y: &W, a: &mut dyn Matrix<Self>);
 }
 
 /// Hermitian packed matrix rank-2 update
 ///
 /// A ← A + αxy<sup>H</sup> + y(αx)<sup>H</sup>
 pub trait Hpr2: Sized {
-    fn hpr2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, y: &W, a: &mut Matrix<Self>);
+    fn hpr2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, y: &W, a: &mut dyn Matrix<Self>);
 }
 
 macro_rules! spr2_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
     $(
         impl $trait_name for $t {
-            fn $fn_name<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, x: &V, y: &W, a: &mut Matrix<$t>) {
+            fn $fn_name<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &$t, x: &V, y: &W, a: &mut dyn Matrix<$t>) {
                 unsafe {
                     prefix!($t, $fn_name)(a.order(), symmetry,
                         a.rows(),

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -24,7 +24,7 @@ pub trait Vector<T> {
     fn as_mut_ptr(&mut self) -> *mut T;
 }
 
-impl<'a, T> Into<Vec<T>> for &'a Vector<T>
+impl<'a, T> Into<Vec<T>> for &'a dyn Vector<T>
     where T: Copy {
 
     fn into(self) -> Vec<T> {
@@ -42,7 +42,7 @@ pub trait VectorOperations<T>: Sized + Vector<T>
     where T: Copy + Axpy + Scal + Dot + Nrm2 + Asum + Iamax {
 
     #[inline]
-    fn update(&mut self, alpha: &T, x: &Vector<T>) -> &mut Self {
+    fn update(&mut self, alpha: &T, x: &dyn Vector<T>) -> &mut Self {
         Axpy::axpy(alpha, x, self);
         self
     }
@@ -54,7 +54,7 @@ pub trait VectorOperations<T>: Sized + Vector<T>
     }
 
     #[inline]
-    fn dot(&self, x: &Vector<T>) -> T {
+    fn dot(&self, x: &dyn Vector<T>) -> T {
         Dot::dot(self, x)
     }
 

--- a/src/vector/ops.rs
+++ b/src/vector/ops.rs
@@ -17,7 +17,7 @@ pub trait Copy: Sized {
     /// Copies `src.len()` elements of `src` into `dst`.
     fn copy<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(src: &V, dst: &mut W);
     /// Copies the entire matrix `dst` into `src`.
-    fn copy_mat(src: &Matrix<Self>, dst: &mut Matrix<Self>);
+    fn copy_mat(src: &dyn Matrix<Self>, dst: &mut dyn Matrix<Self>);
 }
 
 macro_rules! copy_impl(($($t: ident), +) => (
@@ -31,7 +31,7 @@ macro_rules! copy_impl(($($t: ident), +) => (
                 }
             }
 
-            fn copy_mat(src: &Matrix<Self>, dst: &mut Matrix<Self>) {
+            fn copy_mat(src: &dyn Matrix<Self>, dst: &mut dyn Matrix<Self>) {
                 let len = dst.rows() * dst.cols();
 
                 unsafe {
@@ -49,7 +49,7 @@ copy_impl!(f32, f64, Complex32, Complex64);
 /// Computes `a * x + y` and stores the result in `y`.
 pub trait Axpy: Sized {
     fn axpy<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(alpha: &Self, x: &V, y: &mut W);
-    fn axpy_mat(alpha: &Self, x: &Matrix<Self>, y: &mut Matrix<Self>);
+    fn axpy_mat(alpha: &Self, x: &dyn Matrix<Self>, y: &mut dyn Matrix<Self>);
 }
 
 macro_rules! axpy_impl(($($t: ident), +) => (
@@ -66,7 +66,7 @@ macro_rules! axpy_impl(($($t: ident), +) => (
                 }
             }
 
-            fn axpy_mat(alpha: &$t, x: &Matrix<$t>, y: &mut Matrix<$t>) {
+            fn axpy_mat(alpha: &$t, x: &dyn Matrix<$t>, y: &mut dyn Matrix<$t>) {
                 unsafe {
                     let x_len = x.rows() * x.cols();
                     let y_len = y.rows() * y.cols();
@@ -126,7 +126,7 @@ mod axpy_tests {
 /// Computes `a * x` and stores the result in `x`.
 pub trait Scal: Sized {
     fn scal<V: ?Sized + Vector<Self>>(alpha: &Self, x: &mut V);
-    fn scal_mat(alpha: &Self, x: &mut Matrix<Self>);
+    fn scal_mat(alpha: &Self, x: &mut dyn Matrix<Self>);
 }
 
 macro_rules! scal_impl(($($t: ident), +) => (
@@ -141,7 +141,7 @@ macro_rules! scal_impl(($($t: ident), +) => (
                 }
             }
 
-            fn scal_mat(alpha: &$t, x: &mut Matrix<$t>) {
+            fn scal_mat(alpha: &$t, x: &mut dyn Matrix<$t>) {
                 unsafe {
                     prefix!($t, scal)(x.rows() * x.cols(),
                         alpha.as_const(),


### PR DESCRIPTION
Fixes all warnings while running on recent Rust versions by adding `dyn` to trait objects and removing 2 unused `use` statements...