### PR TITLE
chore/libc: Got rid of usage of c_int

### DIFF
--- a/examples/math.rs
+++ b/examples/math.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate rblas as blas;
+use blas::math::Marker::T;
 use blas::math::Mat;
 use blas::{Matrix, Vector};
-use blas::math::Marker::T;
 
 fn main() {
     let x = vec![1.0, 2.0];

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -7,35 +7,35 @@
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub enum Order {
-    RowMajor=101,
-    ColMajor=102,
+    RowMajor = 101,
+    ColMajor = 102,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub enum Transpose {
-    NoTrans=111,
-    Trans=112,
-    ConjTrans=113,
+    NoTrans = 111,
+    Trans = 112,
+    ConjTrans = 113,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub enum Symmetry {
-    Upper=121,
-    Lower=122,
+    Upper = 121,
+    Lower = 122,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub enum Diagonal {
-    NonUnit=131,
-    Unit=132,
+    NonUnit = 131,
+    Unit = 132,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub enum Side {
-    Left=141,
-    Right=142,
+    Left = 141,
+    Right = 142,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,12 @@
 extern crate libc;
 extern crate num;
 
+pub use matrix::ops::*;
+pub use matrix::Matrix;
+pub use matrix_vector::ops::*;
+pub use vector::ops::*;
 pub use vector::Vector;
 pub use vector::VectorOperations;
-pub use matrix::Matrix;
-pub use vector::ops::*;
-pub use matrix_vector::ops::*;
-pub use matrix::ops::*;
 
 #[macro_use]
 mod prefix;
@@ -34,8 +34,8 @@ mod scalar;
 
 pub mod attribute;
 pub mod default;
-pub mod vector;
-pub mod matrix_vector;
 pub mod matrix;
+pub mod matrix_vector;
+pub mod vector;
 
 pub mod math;

--- a/src/math/bandmat.rs
+++ b/src/math/bandmat.rs
@@ -1,7 +1,6 @@
 // Copyright 2015 Michael Yang. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
-use libc::c_int as c_int;
 use num::traits::NumCast;
 use std::fmt;
 use std::iter::repeat;
@@ -16,13 +15,13 @@ use math::Mat;
 pub struct BandMat<T> {
     rows: usize,
     cols: usize,
-    sub_diagonals: c_int,
-    sup_diagonals: c_int,
+    sub_diagonals: u32,
+    sup_diagonals: u32,
     data: Vec<T>,
 }
 
 impl<T> BandMat<T> {
-    pub fn new(n: usize, m: usize, sub: c_int, sup: c_int) -> BandMat<T> {
+    pub fn new(n: usize, m: usize, sub: u32, sup: u32) -> BandMat<T> {
         let len = n * m;
         let mut data = Vec::with_capacity(len);
         unsafe {
@@ -51,10 +50,10 @@ impl<T> BandMat<T> {
         self.cols = n;
     }
 
-    pub unsafe fn set_sub_diagonals(&mut self, n: c_int) {
+    pub unsafe fn set_sub_diagonals(&mut self, n: u32) {
         self.sub_diagonals = n;
     }
-    pub unsafe fn set_sup_diagonals(&mut self, n: c_int) {
+    pub unsafe fn set_sup_diagonals(&mut self, n: u32) {
         self.sup_diagonals = n;
     }
 
@@ -62,7 +61,7 @@ impl<T> BandMat<T> {
         self.data.push(val);
     }
 
-    pub unsafe fn from_matrix(mut mat: Mat<T>, sub_diagonals: c_int, sup_diagonals: c_int) -> BandMat<T> {
+    pub unsafe fn from_matrix(mut mat: Mat<T>, sub_diagonals: u32, sup_diagonals: u32) -> BandMat<T> {
         let data = mat.as_mut_ptr();
         let length = mat.cols() * mat.rows();
         BandMat {
@@ -81,8 +80,8 @@ impl<T: Clone> BandMat<T> {
             rows: n,
             cols: m,
             data: repeat(value).take(n * m).collect(),
-            sub_diagonals: n as c_int,
-            sup_diagonals: m as c_int,
+            sub_diagonals: n as u32,
+            sup_diagonals: m as u32,
         }
     }
 }
@@ -121,13 +120,13 @@ impl<T: fmt::Display> fmt::Display for BandMat<T> {
 }
 
 impl<T> Matrix<T> for BandMat<T> {
-    fn rows(&self) -> i32 {
-        let n: Option<i32> = NumCast::from(self.rows);
+    fn rows(&self) -> u32 {
+        let n: Option<u32> = NumCast::from(self.rows);
         n.unwrap()
     }
 
-    fn cols(&self) -> i32 {
-        let n: Option<i32> = NumCast::from(self.cols);
+    fn cols(&self) -> u32 {
+        let n: Option<u32> = NumCast::from(self.cols);
         n.unwrap()
     }
 
@@ -141,11 +140,11 @@ impl<T> Matrix<T> for BandMat<T> {
 }
 
 impl<T> BandMatrix<T> for BandMat<T> {
-    fn sub_diagonals(&self) -> i32 {
+    fn sub_diagonals(&self) -> u32 {
         self.sub_diagonals
     }
 
-    fn sup_diagonals(&self) -> i32 {
+    fn sup_diagonals(&self) -> u32 {
         self.sup_diagonals
     }
 
@@ -161,8 +160,8 @@ where
         let m = a.cols() as usize;
         let len = n * m;
 
-        let sub = a.sub_diagonals() as c_int;
-        let sup = a.sup_diagonals() as c_int;
+        let sub = a.sub_diagonals() as u32;
+        let sup = a.sup_diagonals() as u32;
 
         let mut result = BandMat {
             rows: n,

--- a/src/math/bandmat.rs
+++ b/src/math/bandmat.rs
@@ -1,15 +1,15 @@
 // Copyright 2015 Michael Yang. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
+use math::Mat;
+use matrix::BandMatrix;
 use num::traits::NumCast;
 use std::fmt;
 use std::iter::repeat;
 use std::ops::Index;
 use std::slice;
 use vector::ops::Copy;
-use matrix::BandMatrix;
 use Matrix;
-use math::Mat;
 
 #[derive(Debug, PartialEq)]
 pub struct BandMat<T> {
@@ -61,7 +61,11 @@ impl<T> BandMat<T> {
         self.data.push(val);
     }
 
-    pub unsafe fn from_matrix(mut mat: Mat<T>, sub_diagonals: u32, sup_diagonals: u32) -> BandMat<T> {
+    pub unsafe fn from_matrix(
+        mut mat: Mat<T>,
+        sub_diagonals: u32,
+        sup_diagonals: u32,
+    ) -> BandMat<T> {
         let data = mat.as_mut_ptr();
         let length = mat.cols() * mat.rows();
         BandMat {
@@ -148,7 +152,9 @@ impl<T> BandMatrix<T> for BandMat<T> {
         self.sup_diagonals
     }
 
-    fn as_matrix(&self) -> &dyn Matrix<T> { self }
+    fn as_matrix(&self) -> &dyn Matrix<T> {
+        self
+    }
 }
 
 impl<'a, T> From<&'a dyn BandMatrix<T>> for BandMat<T>

--- a/src/math/mat.rs
+++ b/src/math/mat.rs
@@ -3,13 +3,13 @@
 // license that can be found in the LICENSE file.
 #![macro_use]
 
+use num::traits::NumCast;
 use std::fmt;
 use std::iter::repeat;
 use std::ops::Index;
 use std::slice;
-use num::traits::NumCast;
-use Matrix;
 use vector::ops::Copy;
+use Matrix;
 
 #[derive(Debug, PartialEq)]
 pub struct Mat<T> {
@@ -22,7 +22,9 @@ impl<T> Mat<T> {
     pub fn new(n: usize, m: usize) -> Mat<T> {
         let len = n * m;
         let mut data = Vec::with_capacity(len);
-        unsafe { data.set_len(len); }
+        unsafe {
+            data.set_len(len);
+        }
 
         Mat {
             rows: n,
@@ -31,10 +33,18 @@ impl<T> Mat<T> {
         }
     }
 
-    pub fn rows(&self) -> usize { self.rows }
-    pub fn cols(&self) -> usize { self.cols }
-    pub unsafe fn set_rows(&mut self, n: usize) { self.rows = n; }
-    pub unsafe fn set_cols(&mut self, n: usize) { self.cols = n; }
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+    pub unsafe fn set_rows(&mut self, n: usize) {
+        self.rows = n;
+    }
+    pub unsafe fn set_cols(&mut self, n: usize) {
+        self.cols = n;
+    }
 
     pub unsafe fn push(&mut self, val: T) {
         self.data.push(val);
@@ -105,7 +115,8 @@ impl<T> Matrix<T> for Mat<T> {
 }
 
 impl<'a, T> From<&'a dyn Matrix<T>> for Mat<T>
-    where T: Copy
+where
+    T: Copy,
 {
     fn from(a: &dyn Matrix<T>) -> Mat<T> {
         let n = a.rows() as usize;
@@ -117,7 +128,9 @@ impl<'a, T> From<&'a dyn Matrix<T>> for Mat<T>
             cols: m,
             data: Vec::with_capacity(len),
         };
-        unsafe { result.data.set_len(len); }
+        unsafe {
+            result.data.set_len(len);
+        }
 
         Copy::copy_mat(a, &mut result);
         result

--- a/src/math/mat.rs
+++ b/src/math/mat.rs
@@ -85,13 +85,13 @@ impl<T: fmt::Display> fmt::Display for Mat<T> {
 }
 
 impl<T> Matrix<T> for Mat<T> {
-    fn rows(&self) -> i32 {
-        let n: Option<i32> = NumCast::from(self.rows);
+    fn rows(&self) -> u32 {
+        let n: Option<u32> = NumCast::from(self.rows);
         n.unwrap()
     }
 
-    fn cols(&self) -> i32 {
-        let n: Option<i32> = NumCast::from(self.cols);
+    fn cols(&self) -> u32 {
+        let n: Option<u32> = NumCast::from(self.cols);
         n.unwrap()
     }
 

--- a/src/math/matrix.rs
+++ b/src/math/matrix.rs
@@ -2,21 +2,19 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use std::ops::{
-    Add,
-    Mul,
-};
-use num::complex::{Complex32, Complex64};
 use attribute::Transpose;
 use default::Default;
+use math::Mat;
 use math::Trans;
 use matrix::ops::*;
 use matrix::Matrix;
-use math::Mat;
+use num::complex::{Complex32, Complex64};
+use std::ops::{Add, Mul};
 use vector::ops::*;
 
 impl<'a, T> Add for &'a dyn Matrix<T>
-    where T: Axpy + Copy + Default
+where
+    T: Axpy + Copy + Default,
 {
     type Output = Mat<T>;
 
@@ -33,7 +31,8 @@ impl<'a, T> Add for &'a dyn Matrix<T>
 }
 
 impl<'a, T> Mul<T> for &'a dyn Matrix<T>
-    where T: Sized + Copy + Scal
+where
+    T: Sized + Copy + Scal,
 {
     type Output = Mat<T>;
 
@@ -62,7 +61,8 @@ macro_rules! left_scale(($($t: ident), +) => (
 left_scale!(f32, f64, Complex32, Complex64);
 
 impl<'a, T> Mul<&'a dyn Matrix<T>> for &'a dyn Matrix<T>
-    where T: Default + Gemm,
+where
+    T: Default + Gemm,
 {
     type Output = Mat<T>;
 
@@ -76,13 +76,22 @@ impl<'a, T> Mul<&'a dyn Matrix<T>> for &'a dyn Matrix<T>
         let mut result = Mat::new(n, m);
         let t = Transpose::NoTrans;
 
-        Gemm::gemm(&Default::one(), t, self, t, b, &Default::zero(), &mut result);
+        Gemm::gemm(
+            &Default::one(),
+            t,
+            self,
+            t,
+            b,
+            &Default::zero(),
+            &mut result,
+        );
         result
     }
 }
 
 impl<'a, T> Mul<&'a dyn Matrix<T>> for Trans<&'a dyn Matrix<T>>
-    where T: Default + Gemm,
+where
+    T: Default + Gemm,
 {
     type Output = Mat<T>;
 
@@ -107,7 +116,8 @@ impl<'a, T> Mul<&'a dyn Matrix<T>> for Trans<&'a dyn Matrix<T>>
 }
 
 impl<'a, T> Mul<Trans<&'a dyn Matrix<T>>> for &'a dyn Matrix<T>
-    where T: Default + Gemm,
+where
+    T: Default + Gemm,
 {
     type Output = Mat<T>;
 
@@ -126,13 +136,22 @@ impl<'a, T> Mul<Trans<&'a dyn Matrix<T>>> for &'a dyn Matrix<T>
         let mut result = Mat::new(n, m);
         let at = Transpose::NoTrans;
 
-        Gemm::gemm(&Default::one(), at, self, bt, b, &Default::zero(), &mut result);
+        Gemm::gemm(
+            &Default::one(),
+            at,
+            self,
+            bt,
+            b,
+            &Default::zero(),
+            &mut result,
+        );
         result
     }
 }
 
 impl<'a, T> Mul<Trans<&'a dyn Matrix<T>>> for Trans<&'a dyn Matrix<T>>
-    where T: Default + Gemm,
+where
+    T: Default + Gemm,
 {
     type Output = Mat<T>;
 
@@ -162,9 +181,9 @@ impl<'a, T> Mul<Trans<&'a dyn Matrix<T>>> for Trans<&'a dyn Matrix<T>>
 
 #[cfg(test)]
 mod tests {
-    use Matrix;
-    use math::Mat;
     use math::Marker::T;
+    use math::Mat;
+    use Matrix;
 
     #[test]
     fn add() {

--- a/src/math/matrix_vector.rs
+++ b/src/math/matrix_vector.rs
@@ -2,26 +2,27 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use std::ops::{
-    Mul,
-};
 use attribute::Transpose;
 use default::Default;
-use vector::Vector;
-use matrix_vector::ops::*;
-use matrix::Matrix;
-use math::Trans;
 use math::Mat;
+use math::Trans;
+use matrix::Matrix;
+use matrix_vector::ops::*;
+use std::ops::Mul;
+use vector::Vector;
 
 impl<'a, T> Mul<&'a dyn Vector<T>> for &'a dyn Matrix<T>
-    where T: Default + Copy + Gemv
+where
+    T: Default + Copy + Gemv,
 {
     type Output = Vec<T>;
 
     fn mul(self, x: &dyn Vector<T>) -> Vec<T> {
         let n = self.rows() as usize;
         let mut result = Vec::with_capacity(n);
-        unsafe { result.set_len(n); }
+        unsafe {
+            result.set_len(n);
+        }
         let scale = Default::one();
         let clear = Default::zero();
         let t = Transpose::NoTrans;
@@ -32,7 +33,8 @@ impl<'a, T> Mul<&'a dyn Vector<T>> for &'a dyn Matrix<T>
 }
 
 impl<'a, T> Mul<Trans<&'a dyn Vector<T>>> for &'a dyn Vector<T>
-    where T: Default + Ger + Gerc + Clone,
+where
+    T: Default + Ger + Gerc + Clone,
 {
     type Output = Mat<T>;
 
@@ -53,10 +55,10 @@ impl<'a, T> Mul<Trans<&'a dyn Vector<T>>> for &'a dyn Vector<T>
 
 #[cfg(test)]
 mod tests {
-    use Vector;
-    use Matrix;
-    use math::Mat;
     use math::Marker::T;
+    use math::Mat;
+    use Matrix;
+    use Vector;
 
     #[test]
     fn mul() {

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -2,20 +2,17 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use std::ops::{
-    BitXor,
-    Deref,
-};
 use matrix::Matrix;
+use std::ops::{BitXor, Deref};
 use vector::Vector;
 
 pub use self::mat::Mat;
 
 pub mod mat;
 pub mod bandmat;
-pub mod vector;
-pub mod matrix_vector;
 pub mod matrix;
+pub mod matrix_vector;
+pub mod vector;
 
 pub enum Trans<A> {
     T(A),
@@ -38,8 +35,7 @@ pub enum Marker {
     H,
 }
 
-impl<'a, T> BitXor<Marker> for &'a dyn Vector<T>
-{
+impl<'a, T> BitXor<Marker> for &'a dyn Vector<T> {
     type Output = Trans<&'a dyn Vector<T>>;
 
     fn bitxor(self, m: Marker) -> Trans<&'a dyn Vector<T>> {
@@ -50,8 +46,7 @@ impl<'a, T> BitXor<Marker> for &'a dyn Vector<T>
     }
 }
 
-impl<'a, T> BitXor<Marker> for &'a dyn Matrix<T>
-{
+impl<'a, T> BitXor<Marker> for &'a dyn Matrix<T> {
     type Output = Trans<&'a dyn Matrix<T>>;
 
     fn bitxor(self, m: Marker) -> Trans<&'a dyn Matrix<T>> {

--- a/src/math/vector.rs
+++ b/src/math/vector.rs
@@ -2,18 +2,16 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use std::ops::{
-    Add,
-    Mul,
-};
-use num::complex::{Complex32, Complex64};
 use default::Default;
+use math::Trans;
+use num::complex::{Complex32, Complex64};
+use std::ops::{Add, Mul};
 use vector::ops::*;
 use vector::Vector;
-use math::Trans;
 
 impl<'a, T> Add for &'a dyn Vector<T>
-    where T: Axpy + Copy + Default
+where
+    T: Axpy + Copy + Default,
 {
     type Output = Vec<T>;
 
@@ -27,7 +25,8 @@ impl<'a, T> Add for &'a dyn Vector<T>
 }
 
 impl<'a, T> Mul<&'a dyn Vector<T>> for Trans<&'a dyn Vector<T>>
-    where T: Sized + Copy + Dot + Dotc
+where
+    T: Sized + Copy + Dot + Dotc,
 {
     type Output = T;
 
@@ -40,7 +39,8 @@ impl<'a, T> Mul<&'a dyn Vector<T>> for Trans<&'a dyn Vector<T>>
 }
 
 impl<'a, T> Mul<T> for &'a dyn Vector<T>
-    where T: Sized + Copy + Scal
+where
+    T: Sized + Copy + Scal,
 {
     type Output = Vec<T>;
 
@@ -70,9 +70,9 @@ left_scale!(f32, f64, Complex32, Complex64);
 
 #[cfg(test)]
 mod tests {
-    use Vector;
-    use math::Marker::{T, H};
+    use math::Marker::{H, T};
     use num::complex::Complex;
+    use Vector;
 
     #[test]
     fn add() {

--- a/src/matrix/ll.rs
+++ b/src/matrix/ll.rs
@@ -5,7 +5,7 @@
 //! Bindings for matrix functions.
 
 pub mod cblas_s {
-    use libc::{c_float, c_int};
+    use libc::{c_float};
     use attribute::{
         Order,
         Transpose,
@@ -22,17 +22,17 @@ pub mod cblas_s {
     pub use self::cblas_ssyr2k as syr2k;
 
     extern {
-        pub fn cblas_sgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: c_int, n: c_int, k: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *const c_float,  ldb: c_int, beta: c_float,       c: *mut c_float,  ldc: c_int);
-        pub fn cblas_ssymm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *const c_float,  ldb: c_int, beta: c_float,       c: *mut c_float,  ldc: c_int);
-        pub fn cblas_strmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *mut c_float,  ldb: c_int);
-        pub fn cblas_strsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *mut c_float,  ldb: c_int);
-        pub fn cblas_ssyrk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, beta: c_float,       c: *mut c_float,  ldc: c_int);
-        pub fn cblas_ssyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, b: *const c_float,  ldb: c_int, beta: c_float,       c: *mut c_float,  ldc: c_int);
+        pub fn cblas_sgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *const c_float,  ldb: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
+        pub fn cblas_ssymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *const c_float,  ldb: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
+        pub fn cblas_strmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *mut c_float,  ldb: u32);
+        pub fn cblas_strsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *mut c_float,  ldb: u32);
+        pub fn cblas_ssyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
+        pub fn cblas_ssyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *const c_float,  ldb: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
     }
 }
 
 pub mod cblas_d {
-    use libc::{c_double, c_int};
+    use libc::{c_double};
     use attribute::{
         Order,
         Transpose,
@@ -49,17 +49,17 @@ pub mod cblas_d {
     pub use self::cblas_dsyr2k as syr2k;
 
     extern {
-        pub fn cblas_dgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: c_int, n: c_int, k: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, b: *const c_double,  ldb: c_int, beta: c_double,       c: *mut c_double,  ldc: c_int);
-        pub fn cblas_dsymm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, b: *const c_double,  ldb: c_int, beta: c_double,       c: *mut c_double,  ldc: c_int);
-        pub fn cblas_dtrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, b: *mut c_double,  ldb: c_int);
-        pub fn cblas_dtrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, b: *mut c_double,  ldb: c_int);
-        pub fn cblas_dsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, beta: c_double,       c: *mut c_double,  ldc: c_int);
-        pub fn cblas_dsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, b: *const c_double,  ldb: c_int, beta: c_double,       c: *mut c_double,  ldc: c_int);
+        pub fn cblas_dgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *const c_double,  ldb: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
+        pub fn cblas_dsymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *const c_double,  ldb: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
+        pub fn cblas_dtrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *mut c_double,  ldb: u32);
+        pub fn cblas_dtrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *mut c_double,  ldb: u32);
+        pub fn cblas_dsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
+        pub fn cblas_dsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *const c_double,  ldb: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
     }
 }
 
 pub mod cblas_c {
-    use libc::{c_float, c_int, c_void};
+    use libc::{c_float, c_void};
     use attribute::{
         Order,
         Transpose,
@@ -79,20 +79,20 @@ pub mod cblas_c {
     pub use self::cblas_csyr2k as syr2k;
 
     extern {
-        pub fn cblas_cgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: c_int, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
-        pub fn cblas_csymm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
-        pub fn cblas_chemm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
-        pub fn cblas_ctrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *mut c_void,   ldb: c_int);
-        pub fn cblas_ctrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *mut c_void,   ldb: c_int);
-        pub fn cblas_cherk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_float,  a: *const c_void, lda: c_int, beta: c_float,  c: *mut c_void, ldc: c_int);
-        pub fn cblas_cher2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void, lda: c_int, b: *const c_void, ldb: c_int, beta: c_float,  c: *mut c_void, ldc: c_int);
-        pub fn cblas_csyrk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
-        pub fn cblas_csyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+        pub fn cblas_cgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_csymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_chemm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_ctrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
+        pub fn cblas_ctrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
+        pub fn cblas_cherk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_float,  a: *const c_void, lda: u32, beta: c_float,  c: *mut c_void, ldc: u32);
+        pub fn cblas_cher2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void, lda: u32, b: *const c_void, ldb: u32, beta: c_float,  c: *mut c_void, ldc: u32);
+        pub fn cblas_csyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_csyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
     }
 }
 
 pub mod cblas_z {
-    use libc::{c_double, c_int, c_void};
+    use libc::{c_double, c_void};
     use attribute::{
         Order,
         Transpose,
@@ -112,14 +112,14 @@ pub mod cblas_z {
     pub use self::cblas_zsyr2k as syr2k;
 
     extern {
-        pub fn cblas_zgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: c_int, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
-        pub fn cblas_zsymm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
-        pub fn cblas_zhemm(order: Order, side: Side, sym: Symmetry, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
-        pub fn cblas_ztrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *mut c_void,   ldb: c_int);
-        pub fn cblas_ztrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *mut c_void,   ldb: c_int);
-        pub fn cblas_zherk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: c_double, a: *const c_void, lda: c_int, beta: c_double, c: *mut c_void, ldc: c_int);
-        pub fn cblas_zher2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void, lda: c_int, b: *const c_void, ldb: c_int, beta: c_double, c: *mut c_void, ldc: c_int);
-        pub fn cblas_zsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
-        pub fn cblas_zsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, b: *const c_void,   ldb: c_int, beta: *const c_void, c: *mut c_void,   ldc: c_int);
+        pub fn cblas_zgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_zsymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_zhemm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_ztrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
+        pub fn cblas_ztrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
+        pub fn cblas_zherk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_double, a: *const c_void, lda: u32, beta: c_double, c: *mut c_void, ldc: u32);
+        pub fn cblas_zher2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void, lda: u32, b: *const c_void, ldb: u32, beta: c_double, c: *mut c_void, ldc: u32);
+        pub fn cblas_zsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+        pub fn cblas_zsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
     }
 }

--- a/src/matrix/ll.rs
+++ b/src/matrix/ll.rs
@@ -5,121 +5,501 @@
 //! Bindings for matrix functions.
 
 pub mod cblas_s {
-    use libc::{c_float};
-    use attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-        Side,
-    };
+    use attribute::{Diagonal, Order, Side, Symmetry, Transpose};
+    use libc::c_float;
 
     pub use self::cblas_sgemm as gemm;
     pub use self::cblas_ssymm as symm;
+    pub use self::cblas_ssyr2k as syr2k;
+    pub use self::cblas_ssyrk as syrk;
     pub use self::cblas_strmm as trmm;
     pub use self::cblas_strsm as strsm;
-    pub use self::cblas_ssyrk as syrk;
-    pub use self::cblas_ssyr2k as syr2k;
 
-    extern {
-        pub fn cblas_sgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *const c_float,  ldb: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
-        pub fn cblas_ssymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *const c_float,  ldb: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
-        pub fn cblas_strmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *mut c_float,  ldb: u32);
-        pub fn cblas_strsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *mut c_float,  ldb: u32);
-        pub fn cblas_ssyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
-        pub fn cblas_ssyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, b: *const c_float,  ldb: u32, beta: c_float,       c: *mut c_float,  ldc: u32);
+    extern "C" {
+        pub fn cblas_sgemm(
+            order: Order,
+            trans_a: Transpose,
+            trans_b: Transpose,
+            m: u32,
+            n: u32,
+            k: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            b: *const c_float,
+            ldb: u32,
+            beta: c_float,
+            c: *mut c_float,
+            ldc: u32,
+        );
+        pub fn cblas_ssymm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            m: u32,
+            n: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            b: *const c_float,
+            ldb: u32,
+            beta: c_float,
+            c: *mut c_float,
+            ldc: u32,
+        );
+        pub fn cblas_strmm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            b: *mut c_float,
+            ldb: u32,
+        );
+        pub fn cblas_strsm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            b: *mut c_float,
+            ldb: u32,
+        );
+        pub fn cblas_ssyrk(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            beta: c_float,
+            c: *mut c_float,
+            ldc: u32,
+        );
+        pub fn cblas_ssyr2k(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            b: *const c_float,
+            ldb: u32,
+            beta: c_float,
+            c: *mut c_float,
+            ldc: u32,
+        );
     }
 }
 
 pub mod cblas_d {
-    use libc::{c_double};
-    use attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-        Side,
-    };
+    use attribute::{Diagonal, Order, Side, Symmetry, Transpose};
+    use libc::c_double;
 
     pub use self::cblas_dgemm as gemm;
     pub use self::cblas_dsymm as symm;
+    pub use self::cblas_dsyr2k as syr2k;
+    pub use self::cblas_dsyrk as syrk;
     pub use self::cblas_dtrmm as trmm;
     pub use self::cblas_dtrsm as strsm;
-    pub use self::cblas_dsyrk as syrk;
-    pub use self::cblas_dsyr2k as syr2k;
 
-    extern {
-        pub fn cblas_dgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *const c_double,  ldb: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
-        pub fn cblas_dsymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *const c_double,  ldb: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
-        pub fn cblas_dtrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *mut c_double,  ldb: u32);
-        pub fn cblas_dtrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *mut c_double,  ldb: u32);
-        pub fn cblas_dsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
-        pub fn cblas_dsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, b: *const c_double,  ldb: u32, beta: c_double,       c: *mut c_double,  ldc: u32);
+    extern "C" {
+        pub fn cblas_dgemm(
+            order: Order,
+            trans_a: Transpose,
+            trans_b: Transpose,
+            m: u32,
+            n: u32,
+            k: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            b: *const c_double,
+            ldb: u32,
+            beta: c_double,
+            c: *mut c_double,
+            ldc: u32,
+        );
+        pub fn cblas_dsymm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            m: u32,
+            n: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            b: *const c_double,
+            ldb: u32,
+            beta: c_double,
+            c: *mut c_double,
+            ldc: u32,
+        );
+        pub fn cblas_dtrmm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            b: *mut c_double,
+            ldb: u32,
+        );
+        pub fn cblas_dtrsm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            b: *mut c_double,
+            ldb: u32,
+        );
+        pub fn cblas_dsyrk(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            beta: c_double,
+            c: *mut c_double,
+            ldc: u32,
+        );
+        pub fn cblas_dsyr2k(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            b: *const c_double,
+            ldb: u32,
+            beta: c_double,
+            c: *mut c_double,
+            ldc: u32,
+        );
     }
 }
 
 pub mod cblas_c {
+    use attribute::{Diagonal, Order, Side, Symmetry, Transpose};
     use libc::{c_float, c_void};
-    use attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-        Side,
-    };
 
     pub use self::cblas_cgemm as gemm;
-    pub use self::cblas_csymm as symm;
     pub use self::cblas_chemm as hemm;
+    pub use self::cblas_cher2k as her2k;
+    pub use self::cblas_cherk as herk;
+    pub use self::cblas_csymm as symm;
+    pub use self::cblas_csyr2k as syr2k;
+    pub use self::cblas_csyrk as syrk;
     pub use self::cblas_ctrmm as trmm;
     pub use self::cblas_ctrsm as trsm;
-    pub use self::cblas_cherk as herk;
-    pub use self::cblas_cher2k as her2k;
-    pub use self::cblas_csyrk as syrk;
-    pub use self::cblas_csyr2k as syr2k;
 
-    extern {
-        pub fn cblas_cgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_csymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_chemm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_ctrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
-        pub fn cblas_ctrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
-        pub fn cblas_cherk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_float,  a: *const c_void, lda: u32, beta: c_float,  c: *mut c_void, ldc: u32);
-        pub fn cblas_cher2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void, lda: u32, b: *const c_void, ldb: u32, beta: c_float,  c: *mut c_void, ldc: u32);
-        pub fn cblas_csyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_csyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+    extern "C" {
+        pub fn cblas_cgemm(
+            order: Order,
+            trans_a: Transpose,
+            trans_b: Transpose,
+            m: u32,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_csymm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_chemm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_ctrmm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *mut c_void,
+            ldb: u32,
+        );
+        pub fn cblas_ctrsm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *mut c_void,
+            ldb: u32,
+        );
+        pub fn cblas_cherk(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: c_float,
+            a: *const c_void,
+            lda: u32,
+            beta: c_float,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_cher2k(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: c_float,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_csyrk(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_csyr2k(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
     }
 }
 
 pub mod cblas_z {
+    use attribute::{Diagonal, Order, Side, Symmetry, Transpose};
     use libc::{c_double, c_void};
-    use attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-        Side,
-    };
 
     pub use self::cblas_zgemm as gemm;
-    pub use self::cblas_zsymm as symm;
     pub use self::cblas_zhemm as hemm;
+    pub use self::cblas_zher2k as her2k;
+    pub use self::cblas_zherk as herk;
+    pub use self::cblas_zsymm as symm;
+    pub use self::cblas_zsyr2k as syr2k;
+    pub use self::cblas_zsyrk as syrk;
     pub use self::cblas_ztrmm as trmm;
     pub use self::cblas_ztrsm as trsm;
-    pub use self::cblas_zherk as herk;
-    pub use self::cblas_zher2k as her2k;
-    pub use self::cblas_zsyrk as syrk;
-    pub use self::cblas_zsyr2k as syr2k;
 
-    extern {
-        pub fn cblas_zgemm(order: Order, trans_a: Transpose, trans_b: Transpose, m: u32, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_zsymm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_zhemm(order: Order, side: Side, sym: Symmetry, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_ztrmm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
-        pub fn cblas_ztrsm(order: Order, side: Side, sym: Symmetry, trans: Transpose, diag: Diagonal, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *mut c_void,   ldb: u32);
-        pub fn cblas_zherk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: c_double, a: *const c_void, lda: u32, beta: c_double, c: *mut c_void, ldc: u32);
-        pub fn cblas_zher2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void, lda: u32, b: *const c_void, ldb: u32, beta: c_double, c: *mut c_void, ldc: u32);
-        pub fn cblas_zsyrk(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
-        pub fn cblas_zsyr2k(order: Order, sym: Symmetry, Trans: Transpose, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, b: *const c_void,   ldb: u32, beta: *const c_void, c: *mut c_void,   ldc: u32);
+    extern "C" {
+        pub fn cblas_zgemm(
+            order: Order,
+            trans_a: Transpose,
+            trans_b: Transpose,
+            m: u32,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_zsymm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_zhemm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_ztrmm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *mut c_void,
+            ldb: u32,
+        );
+        pub fn cblas_ztrsm(
+            order: Order,
+            side: Side,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *mut c_void,
+            ldb: u32,
+        );
+        pub fn cblas_zherk(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: c_double,
+            a: *const c_void,
+            lda: u32,
+            beta: c_double,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_zher2k(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: c_double,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_zsyrk(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
+        pub fn cblas_zsyr2k(
+            order: Order,
+            sym: Symmetry,
+            Trans: Transpose,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            b: *const c_void,
+            ldb: u32,
+            beta: *const c_void,
+            c: *mut c_void,
+            ldc: u32,
+        );
     }
 }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //! Matrix operations.
-use libc::c_int;
 use attribute::{
     Order,
 };
@@ -15,7 +14,7 @@ pub mod ops;
 pub trait Matrix<T> {
     /// The leading dimension of the matrix. Defaults to `cols` for `RowMajor`
     /// order and 'rows' for `ColMajor` order.
-    fn lead_dim(&self) -> c_int {
+    fn lead_dim(&self) -> u32 {
         match self.order() {
             Order::RowMajor => self.cols(),
             Order::ColMajor => self.rows(),
@@ -24,9 +23,9 @@ pub trait Matrix<T> {
     /// The order of the matrix. Defaults to `RowMajor`.
     fn order(&self) -> Order { Order::RowMajor }
     /// Returns the number of rows.
-    fn rows(&self) -> c_int;
+    fn rows(&self) -> u32;
     /// Returns the number of columns.
-    fn cols(&self) -> c_int;
+    fn cols(&self) -> u32;
     /// An unsafe pointer to a contiguous block of memory.
     fn as_ptr(&self) -> *const T;
     /// An unsafe pointer to a contiguous block of memory.
@@ -34,25 +33,24 @@ pub trait Matrix<T> {
 }
 
 pub trait BandMatrix<T>: Matrix<T> {
-    fn sub_diagonals(&self) -> c_int;
-    fn sup_diagonals(&self) -> c_int;
+    fn sub_diagonals(&self) -> u32;
+    fn sup_diagonals(&self) -> u32;
 
     fn as_matrix(&self) -> &dyn Matrix<T>;
 }
 
 #[cfg(test)]
 pub mod tests {
-    use libc::c_int;
     use matrix::Matrix;
 
-    pub struct M<T>(pub c_int, pub c_int, pub Vec<T>);
+    pub struct M<T>(pub u32, pub u32, pub Vec<T>);
 
     impl<T> Matrix<T> for M<T> {
-        fn rows(&self) -> c_int {
+        fn rows(&self) -> u32 {
             self.0
         }
 
-        fn cols(&self) -> c_int {
+        fn cols(&self) -> u32 {
             self.1
         }
 

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -3,9 +3,7 @@
 // license that can be found in the LICENSE file.
 
 //! Matrix operations.
-use attribute::{
-    Order,
-};
+use attribute::Order;
 
 pub mod ll;
 pub mod ops;
@@ -21,7 +19,9 @@ pub trait Matrix<T> {
         }
     }
     /// The order of the matrix. Defaults to `RowMajor`.
-    fn order(&self) -> Order { Order::RowMajor }
+    fn order(&self) -> Order {
+        Order::RowMajor
+    }
     /// Returns the number of rows.
     fn rows(&self) -> u32;
     /// Returns the number of columns.

--- a/src/matrix/ops.rs
+++ b/src/matrix/ops.rs
@@ -4,15 +4,23 @@
 
 //! Wrappers for matrix functions.
 
-use num::complex::{Complex, Complex32, Complex64};
 use attribute::{Diagonal, Side, Symmetry, Transpose};
-use pointer::CPtr;
-use scalar::Scalar;
 use matrix::ll::*;
 use matrix::Matrix;
+use num::complex::{Complex, Complex32, Complex64};
+use pointer::CPtr;
+use scalar::Scalar;
 
 pub trait Gemm: Sized {
-    fn gemm(alpha: &Self, at: Transpose, a: &dyn Matrix<Self>, bt: Transpose, b: &dyn Matrix<Self>, beta: &Self, c: &mut dyn Matrix<Self>);
+    fn gemm(
+        alpha: &Self,
+        at: Transpose,
+        a: &dyn Matrix<Self>,
+        bt: Transpose,
+        b: &dyn Matrix<Self>,
+        beta: &Self,
+        c: &mut dyn Matrix<Self>,
+    );
 }
 
 macro_rules! gemm_impl(($($t: ident), +) => (
@@ -48,10 +56,10 @@ gemm_impl!(f32, f64, Complex32, Complex64);
 
 #[cfg(test)]
 mod gemm_tests {
-    use std::iter::repeat;
     use attribute::Transpose;
     use matrix::ops::Gemm;
     use matrix::tests::M;
+    use std::iter::repeat;
 
     #[test]
     fn real() {
@@ -67,13 +75,8 @@ mod gemm_tests {
 
     #[test]
     fn transpose() {
-        let a = M(3, 2, vec![
-                 1.0, 2.0,
-                 3.0, 4.0,
-                 5.0, 6.0, ]);
-        let b = M(2, 3, vec![
-                 -1.0, 3.0, 1.0,
-                 1.0, 1.0, 1.0]);
+        let a = M(3, 2, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let b = M(2, 3, vec![-1.0, 3.0, 1.0, 1.0, 1.0, 1.0]);
         let t = Transpose::Trans;
 
         let mut c = M(2, 2, repeat(0.0).take(4).collect());
@@ -84,11 +87,27 @@ mod gemm_tests {
 }
 
 pub trait Symm: Sized {
-    fn symm(side: Side, symmetry: Symmetry, alpha: &Self, a: &dyn Matrix<Self>, b: &dyn Matrix<Self>, beta: &Self, c: &mut dyn Matrix<Self>);
+    fn symm(
+        side: Side,
+        symmetry: Symmetry,
+        alpha: &Self,
+        a: &dyn Matrix<Self>,
+        b: &dyn Matrix<Self>,
+        beta: &Self,
+        c: &mut dyn Matrix<Self>,
+    );
 }
 
 pub trait Hemm: Sized {
-    fn hemm(side: Side, symmetry: Symmetry, alpha: &Self, a: &dyn Matrix<Self>, b: &dyn Matrix<Self>, beta: &Self, c: &mut dyn Matrix<Self>);
+    fn hemm(
+        side: Side,
+        symmetry: Symmetry,
+        alpha: &Self,
+        a: &dyn Matrix<Self>,
+        b: &dyn Matrix<Self>,
+        beta: &Self,
+        c: &mut dyn Matrix<Self>,
+    );
 }
 
 macro_rules! symm_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
@@ -114,11 +133,27 @@ symm_impl!(Symm, symm, f32, f64, Complex32, Complex64);
 symm_impl!(Hemm, hemm, Complex32, Complex64);
 
 pub trait Trmm: Sized {
-    fn trmm(side: Side, symmetry: Symmetry, trans: Transpose, diag: Diagonal, alpha: &Self, a: &dyn Matrix<Self>, b: &mut dyn Matrix<Self>);
+    fn trmm(
+        side: Side,
+        symmetry: Symmetry,
+        trans: Transpose,
+        diag: Diagonal,
+        alpha: &Self,
+        a: &dyn Matrix<Self>,
+        b: &mut dyn Matrix<Self>,
+    );
 }
 
 pub trait Trsm: Sized {
-    fn trsm(side: Side, symmetry: Symmetry, trans: Transpose, diag: Diagonal, alpha: &Self, a: &dyn Matrix<Self>, b: &mut dyn Matrix<Self>);
+    fn trsm(
+        side: Side,
+        symmetry: Symmetry,
+        trans: Transpose,
+        diag: Diagonal,
+        alpha: &Self,
+        a: &dyn Matrix<Self>,
+        b: &mut dyn Matrix<Self>,
+    );
 }
 
 macro_rules! trmm_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
@@ -142,11 +177,26 @@ trmm_impl!(Trmm, trmm, f32, f64, Complex32, Complex64);
 trmm_impl!(Trsm, trsm, Complex32, Complex64);
 
 pub trait Herk: Sized {
-    fn herk(symmetry: Symmetry, trans: Transpose, alpha: &Self, a: &dyn Matrix<Complex<Self>>, beta: &Self, c: &mut dyn Matrix<Complex<Self>>);
+    fn herk(
+        symmetry: Symmetry,
+        trans: Transpose,
+        alpha: &Self,
+        a: &dyn Matrix<Complex<Self>>,
+        beta: &Self,
+        c: &mut dyn Matrix<Complex<Self>>,
+    );
 }
 
 pub trait Her2k: Sized {
-    fn her2k(symmetry: Symmetry, trans: Transpose, alpha: Complex<Self>, a: &dyn Matrix<Complex<Self>>, b: &dyn Matrix<Complex<Self>>, beta: &Self, c: &mut dyn Matrix<Complex<Self>>);
+    fn her2k(
+        symmetry: Symmetry,
+        trans: Transpose,
+        alpha: Complex<Self>,
+        a: &dyn Matrix<Complex<Self>>,
+        b: &dyn Matrix<Complex<Self>>,
+        beta: &Self,
+        c: &mut dyn Matrix<Complex<Self>>,
+    );
 }
 
 macro_rules! herk_impl(($($t: ident), +) => (
@@ -185,11 +235,26 @@ macro_rules! herk_impl(($($t: ident), +) => (
 herk_impl!(f32, f64);
 
 pub trait Syrk: Sized {
-    fn syrk(symmetry: Symmetry, trans: Transpose, alpha: &Self, a: &dyn Matrix<Self>, beta: &Self, c: &mut dyn Matrix<Self>);
+    fn syrk(
+        symmetry: Symmetry,
+        trans: Transpose,
+        alpha: &Self,
+        a: &dyn Matrix<Self>,
+        beta: &Self,
+        c: &mut dyn Matrix<Self>,
+    );
 }
 
 pub trait Syr2k: Sized {
-    fn syr2k(symmetry: Symmetry, trans: Transpose, alpha: &Self, a: &dyn Matrix<Self>, b: &dyn Matrix<Self>, beta: &Self, c: &mut dyn Matrix<Self>);
+    fn syr2k(
+        symmetry: Symmetry,
+        trans: Transpose,
+        alpha: &Self,
+        a: &dyn Matrix<Self>,
+        b: &dyn Matrix<Self>,
+        beta: &Self,
+        c: &mut dyn Matrix<Self>,
+    );
 }
 
 macro_rules! syrk_impl(($($t: ident), +) => (

--- a/src/matrix_vector/ll.rs
+++ b/src/matrix_vector/ll.rs
@@ -5,7 +5,7 @@
 //! Bindings for matrix-vector functions.
 
 pub mod cblas_s {
-    use libc::{c_float, c_int};
+    use libc::{c_float};
     use attribute::{
         Order,
         Transpose,
@@ -31,27 +31,27 @@ pub mod cblas_s {
     pub use self::cblas_sspr2 as spr2;
 
     extern {
-        pub fn cblas_sgemv(order: Order, trans: Transpose, m: c_int, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
-        pub fn cblas_ssymv(order: Order, sym: Symmetry, n: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
-        pub fn cblas_strmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_float,  lda: c_int, x: *mut c_float,  inc_x: c_int);
-        pub fn cblas_strsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_float,  lda: c_int, x: *mut c_float,  inc_x: c_int);
-        pub fn cblas_sger (order: Order, m: c_int, n: c_int, alpha: c_float,       x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int, a: *mut c_float,  lda: c_int);
-        pub fn cblas_ssyr(order: Order, sym: Symmetry, n: c_int, alpha: c_float,  x: *const c_float,  inc_x: c_int, a: *mut c_float,  lda: c_int);
-        pub fn cblas_ssyr2(order: Order, sym: Symmetry, n: c_int, alpha: c_float,       x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int, a: *mut c_float,  lda: c_int);
-        pub fn cblas_sspmv(order: Order, sym: Symmetry, n: c_int, alpha: c_float,       a: *const c_float,  x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
-        pub fn cblas_sgbmv(order: Order, trans: Transpose, m: c_int, n: c_int, kl: c_int, ku: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
-        pub fn cblas_ssbmv(order: Order, sym: Symmetry, n: c_int, k: c_int, alpha: c_float,       a: *const c_float,  lda: c_int, x: *const c_float,  inc_x: c_int, beta: c_float,       y: *mut c_float,  inc_y: c_int);
-        pub fn cblas_stbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_float,  x: *mut c_float,  inc_x: c_int);
-        pub fn cblas_stbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_float,  x: *mut c_float,  inc_x: c_int);
-        pub fn cblas_stpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_float,  x: *mut c_float,  inc_x: c_int);
-        pub fn cblas_stpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_float,  x: *mut c_float,  inc_x: c_int);
-        pub fn cblas_sspr(order: Order, sym: Symmetry, n: c_int, alpha: c_float,  x: *const c_float,  inc_x: c_int, a: *mut c_float);
-        pub fn cblas_sspr2(order: Order, sym: Symmetry, n: c_int, alpha: c_float,       x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int, a: *mut c_float);
+        pub fn cblas_sgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
+        pub fn cblas_ssymv(order: Order, sym: Symmetry, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
+        pub fn cblas_strmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  lda: u32, x: *mut c_float,  inc_x: u32);
+        pub fn cblas_strsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  lda: u32, x: *mut c_float,  inc_x: u32);
+        pub fn cblas_sger (order: Order, m: u32, n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32, a: *mut c_float,  lda: u32);
+        pub fn cblas_ssyr(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_float,  inc_x: u32, a: *mut c_float,  lda: u32);
+        pub fn cblas_ssyr2(order: Order, sym: Symmetry, n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32, a: *mut c_float,  lda: u32);
+        pub fn cblas_sspmv(order: Order, sym: Symmetry, n: u32, alpha: c_float,       a: *const c_float,  x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
+        pub fn cblas_sgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
+        pub fn cblas_ssbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
+        pub fn cblas_stbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
+        pub fn cblas_stbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
+        pub fn cblas_stpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
+        pub fn cblas_stpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
+        pub fn cblas_sspr(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_float,  inc_x: u32, a: *mut c_float);
+        pub fn cblas_sspr2(order: Order, sym: Symmetry, n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32, a: *mut c_float);
     }
 }
 
 pub mod cblas_d {
-    use libc::{c_double, c_int};
+    use libc::{c_double};
     use attribute::{
         Order,
         Transpose,
@@ -77,27 +77,27 @@ pub mod cblas_d {
     pub use self::cblas_dspr2 as spr2;
 
     extern {
-        pub fn cblas_dgemv(order: Order, trans: Transpose, m: c_int, n: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, x: *const c_double,  inc_x: c_int, beta: c_double,       y: *mut c_double,  inc_y: c_int);
-        pub fn cblas_dsymv(order: Order, sym: Symmetry, n: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, x: *const c_double,  inc_x: c_int, beta: c_double,       y: *mut c_double,  inc_y: c_int);
-        pub fn cblas_dtrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_double,  lda: c_int, x: *mut c_double,  inc_x: c_int);
-        pub fn cblas_dtrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_double,  lda: c_int, x: *mut c_double,  inc_x: c_int);
-        pub fn cblas_dger (order: Order, m: c_int, n: c_int, alpha: c_double,       x: *const c_double,  inc_x: c_int, y: *const c_double,  inc_y: c_int, a: *mut c_double,  lda: c_int);
-        pub fn cblas_dsyr(order: Order, sym: Symmetry, n: c_int, alpha: c_double,  x: *const c_double,  inc_x: c_int, a: *mut c_double,  lda: c_int);
-        pub fn cblas_dsyr2(order: Order, sym: Symmetry, n: c_int, alpha: c_double,       x: *const c_double,  inc_x: c_int, y: *const c_double,  inc_y: c_int, a: *mut c_double,  lda: c_int);
-        pub fn cblas_dspmv(order: Order, sym: Symmetry, n: c_int, alpha: c_double,       a: *const c_double,  x: *const c_double,  inc_x: c_int, beta: c_double,       y: *mut c_double,  inc_y: c_int);
-        pub fn cblas_dgbmv(order: Order, trans: Transpose, m: c_int, n: c_int, kl: c_int, ku: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, x: *const c_double,  inc_x: c_int, beta: c_double,       y: *mut c_double,  inc_y: c_int);
-        pub fn cblas_dsbmv(order: Order, sym: Symmetry, n: c_int, k: c_int, alpha: c_double,       a: *const c_double,  lda: c_int, x: *const c_double,  inc_x: c_int, beta: c_double,       y: *mut c_double,  inc_y: c_int);
-        pub fn cblas_dtbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_double,  x: *mut c_double,  inc_x: c_int);
-        pub fn cblas_dtbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_double,  x: *mut c_double,  inc_x: c_int);
-        pub fn cblas_dtpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_double,  x: *mut c_double,  inc_x: c_int);
-        pub fn cblas_dtpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_double,  x: *mut c_double,  inc_x: c_int);
-        pub fn cblas_dspr(order: Order, sym: Symmetry, n: c_int, alpha: c_double,  x: *const c_double,  inc_x: c_int, a: *mut c_double);
-        pub fn cblas_dspr2(order: Order, sym: Symmetry, n: c_int, alpha: c_double,       x: *const c_double,  inc_x: c_int, y: *const c_double,  inc_y: c_int, a: *mut c_double);
+        pub fn cblas_dgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
+        pub fn cblas_dsymv(order: Order, sym: Symmetry, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
+        pub fn cblas_dtrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  lda: u32, x: *mut c_double,  inc_x: u32);
+        pub fn cblas_dtrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  lda: u32, x: *mut c_double,  inc_x: u32);
+        pub fn cblas_dger (order: Order, m: u32, n: u32, alpha: c_double,       x: *const c_double,  inc_x: u32, y: *const c_double,  inc_y: u32, a: *mut c_double,  lda: u32);
+        pub fn cblas_dsyr(order: Order, sym: Symmetry, n: u32, alpha: c_double,  x: *const c_double,  inc_x: u32, a: *mut c_double,  lda: u32);
+        pub fn cblas_dsyr2(order: Order, sym: Symmetry, n: u32, alpha: c_double,       x: *const c_double,  inc_x: u32, y: *const c_double,  inc_y: u32, a: *mut c_double,  lda: u32);
+        pub fn cblas_dspmv(order: Order, sym: Symmetry, n: u32, alpha: c_double,       a: *const c_double,  x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
+        pub fn cblas_dgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
+        pub fn cblas_dsbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
+        pub fn cblas_dtbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
+        pub fn cblas_dtbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
+        pub fn cblas_dtpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
+        pub fn cblas_dtpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
+        pub fn cblas_dspr(order: Order, sym: Symmetry, n: u32, alpha: c_double,  x: *const c_double,  inc_x: u32, a: *mut c_double);
+        pub fn cblas_dspr2(order: Order, sym: Symmetry, n: u32, alpha: c_double,       x: *const c_double,  inc_x: u32, y: *const c_double,  inc_y: u32, a: *mut c_double);
     }
 }
 
 pub mod cblas_c {
-    use libc::{c_float, c_int, c_void};
+    use libc::{c_float, c_void};
     use attribute::{
         Order,
         Transpose,
@@ -125,29 +125,29 @@ pub mod cblas_c {
     pub use self::cblas_chpr2 as hpr2;
 
     extern {
-        pub fn cblas_cgemv(order: Order, trans: Transpose, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_csymv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_chemv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_ctrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   lda: c_int, x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_ctrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   lda: c_int, x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_cgeru(order: Order, m: c_int, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
-        pub fn cblas_cgerc(order: Order, m: c_int, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
-        pub fn cblas_cher(order: Order, sym: Symmetry, n: c_int, alpha: c_float,  x: *const c_void,   inc_x: c_int, a: *mut c_void,   lda: c_int);
-        pub fn cblas_cher2(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
-        pub fn cblas_cgbmv(order: Order, trans: Transpose, m: c_int, n: c_int, kl: c_int, ku: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_chbmv(order: Order, sym: Symmetry, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_ctbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_ctbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_chpmv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_ctpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_ctpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_chpr(order: Order, sym: Symmetry, n: c_int, alpha: c_float,  x: *const c_void,   inc_x: c_int, a: *mut c_void);
-        pub fn cblas_chpr2(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void);
+        pub fn cblas_cgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_csymv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_chemv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_ctrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
+        pub fn cblas_ctrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
+        pub fn cblas_cgeru(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_cgerc(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_cher(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_void,   inc_x: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_cher2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_cgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_chbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_ctbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_ctbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_chpmv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_ctpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_ctpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_chpr(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_void,   inc_x: u32, a: *mut c_void);
+        pub fn cblas_chpr2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void);
     }
 }
 
 pub mod cblas_z {
-    use libc::{c_double, c_int, c_void};
+    use libc::{c_double, c_void};
     use attribute::{
         Order,
         Transpose,
@@ -175,23 +175,23 @@ pub mod cblas_z {
     pub use self::cblas_zhpr2 as hpr2;
 
     extern {
-        pub fn cblas_zgemv(order: Order, trans: Transpose, m: c_int, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_zsymv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_zhemv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_ztrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   lda: c_int, x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_ztrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   lda: c_int, x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_zgeru(order: Order, m: c_int, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
-        pub fn cblas_zgerc(order: Order, m: c_int, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
-        pub fn cblas_zher(order: Order, sym: Symmetry, n: c_int, alpha: c_double, x: *const c_void,   inc_x: c_int, a: *mut c_void,   lda: c_int);
-        pub fn cblas_zher2(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void,   lda: c_int);
-        pub fn cblas_zgbmv(order: Order, trans: Transpose, m: c_int, n: c_int, kl: c_int, ku: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_zhbmv(order: Order, sym: Symmetry, n: c_int, k: c_int, alpha: *const c_void, a: *const c_void,   lda: c_int, x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_ztbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_ztbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, k: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_zhpmv(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: c_int, beta: *const c_void, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_ztpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_ztpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: c_int, a: *const c_void,   x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_zhpr(order: Order, sym: Symmetry, n: c_int, alpha: c_double, x: *const c_void,   inc_x: c_int, a: *mut c_void);
-        pub fn cblas_zhpr2(order: Order, sym: Symmetry, n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *const c_void,   inc_y: c_int, a: *mut c_void);
+        pub fn cblas_zgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_zsymv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_zhemv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_ztrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
+        pub fn cblas_ztrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
+        pub fn cblas_zgeru(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_zgerc(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_zher(order: Order, sym: Symmetry, n: u32, alpha: c_double, x: *const c_void,   inc_x: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_zher2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
+        pub fn cblas_zgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_zhbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_ztbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_ztbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_zhpmv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_ztpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_ztpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
+        pub fn cblas_zhpr(order: Order, sym: Symmetry, n: u32, alpha: c_double, x: *const c_void,   inc_x: u32, a: *mut c_void);
+        pub fn cblas_zhpr2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void);
     }
 }

--- a/src/matrix_vector/ll.rs
+++ b/src/matrix_vector/ll.rs
@@ -5,193 +5,903 @@
 //! Bindings for matrix-vector functions.
 
 pub mod cblas_s {
-    use libc::{c_float};
-    use attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-    };
+    use attribute::{Diagonal, Order, Symmetry, Transpose};
+    use libc::c_float;
 
+    pub use self::cblas_sgbmv as gbmv;
     pub use self::cblas_sgemv as gemv;
-    pub use self::cblas_ssymv as symv;
-    pub use self::cblas_strmv as trmv;
-    pub use self::cblas_strsv as trsv;
     pub use self::cblas_sger as ger;
+    pub use self::cblas_ssbmv as sbmv;
+    pub use self::cblas_sspmv as spmv;
+    pub use self::cblas_sspr as spr;
+    pub use self::cblas_sspr2 as spr2;
+    pub use self::cblas_ssymv as symv;
     pub use self::cblas_ssyr as syr;
     pub use self::cblas_ssyr2 as syr2;
-    pub use self::cblas_sspmv as spmv;
-    pub use self::cblas_sgbmv as gbmv;
-    pub use self::cblas_ssbmv as sbmv;
     pub use self::cblas_stbmv as tbmv;
     pub use self::cblas_stbsv as tbsv;
     pub use self::cblas_stpmv as tpmv;
     pub use self::cblas_stpsv as tpsv;
-    pub use self::cblas_sspr as spr;
-    pub use self::cblas_sspr2 as spr2;
+    pub use self::cblas_strmv as trmv;
+    pub use self::cblas_strsv as trsv;
 
-    extern {
-        pub fn cblas_sgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
-        pub fn cblas_ssymv(order: Order, sym: Symmetry, n: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
-        pub fn cblas_strmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  lda: u32, x: *mut c_float,  inc_x: u32);
-        pub fn cblas_strsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  lda: u32, x: *mut c_float,  inc_x: u32);
-        pub fn cblas_sger (order: Order, m: u32, n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32, a: *mut c_float,  lda: u32);
-        pub fn cblas_ssyr(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_float,  inc_x: u32, a: *mut c_float,  lda: u32);
-        pub fn cblas_ssyr2(order: Order, sym: Symmetry, n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32, a: *mut c_float,  lda: u32);
-        pub fn cblas_sspmv(order: Order, sym: Symmetry, n: u32, alpha: c_float,       a: *const c_float,  x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
-        pub fn cblas_sgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
-        pub fn cblas_ssbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: c_float,       a: *const c_float,  lda: u32, x: *const c_float,  inc_x: u32, beta: c_float,       y: *mut c_float,  inc_y: u32);
-        pub fn cblas_stbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
-        pub fn cblas_stbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
-        pub fn cblas_stpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
-        pub fn cblas_stpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_float,  x: *mut c_float,  inc_x: u32);
-        pub fn cblas_sspr(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_float,  inc_x: u32, a: *mut c_float);
-        pub fn cblas_sspr2(order: Order, sym: Symmetry, n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32, a: *mut c_float);
+    extern "C" {
+        pub fn cblas_sgemv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            x: *const c_float,
+            inc_x: u32,
+            beta: c_float,
+            y: *mut c_float,
+            inc_y: u32,
+        );
+        pub fn cblas_ssymv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            x: *const c_float,
+            inc_x: u32,
+            beta: c_float,
+            y: *mut c_float,
+            inc_y: u32,
+        );
+        pub fn cblas_strmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_float,
+            lda: u32,
+            x: *mut c_float,
+            inc_x: u32,
+        );
+        pub fn cblas_strsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_float,
+            lda: u32,
+            x: *mut c_float,
+            inc_x: u32,
+        );
+        pub fn cblas_sger(
+            order: Order,
+            m: u32,
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            y: *const c_float,
+            inc_y: u32,
+            a: *mut c_float,
+            lda: u32,
+        );
+        pub fn cblas_ssyr(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            a: *mut c_float,
+            lda: u32,
+        );
+        pub fn cblas_ssyr2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            y: *const c_float,
+            inc_y: u32,
+            a: *mut c_float,
+            lda: u32,
+        );
+        pub fn cblas_sspmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            a: *const c_float,
+            x: *const c_float,
+            inc_x: u32,
+            beta: c_float,
+            y: *mut c_float,
+            inc_y: u32,
+        );
+        pub fn cblas_sgbmv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            kl: u32,
+            ku: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            x: *const c_float,
+            inc_x: u32,
+            beta: c_float,
+            y: *mut c_float,
+            inc_y: u32,
+        );
+        pub fn cblas_ssbmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            k: u32,
+            alpha: c_float,
+            a: *const c_float,
+            lda: u32,
+            x: *const c_float,
+            inc_x: u32,
+            beta: c_float,
+            y: *mut c_float,
+            inc_y: u32,
+        );
+        pub fn cblas_stbmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_float,
+            x: *mut c_float,
+            inc_x: u32,
+        );
+        pub fn cblas_stbsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_float,
+            x: *mut c_float,
+            inc_x: u32,
+        );
+        pub fn cblas_stpmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_float,
+            x: *mut c_float,
+            inc_x: u32,
+        );
+        pub fn cblas_stpsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_float,
+            x: *mut c_float,
+            inc_x: u32,
+        );
+        pub fn cblas_sspr(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            a: *mut c_float,
+        );
+        pub fn cblas_sspr2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            y: *const c_float,
+            inc_y: u32,
+            a: *mut c_float,
+        );
     }
 }
 
 pub mod cblas_d {
-    use libc::{c_double};
-    use attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-    };
+    use attribute::{Diagonal, Order, Symmetry, Transpose};
+    use libc::c_double;
 
+    pub use self::cblas_dgbmv as gbmv;
     pub use self::cblas_dgemv as gemv;
-    pub use self::cblas_dsymv as symv;
-    pub use self::cblas_dtrmv as trmv;
-    pub use self::cblas_dtrsv as trsv;
     pub use self::cblas_dger as ger;
+    pub use self::cblas_dsbmv as sbmv;
+    pub use self::cblas_dspmv as spmv;
+    pub use self::cblas_dspr as spr;
+    pub use self::cblas_dspr2 as spr2;
+    pub use self::cblas_dsymv as symv;
     pub use self::cblas_dsyr as syr;
     pub use self::cblas_dsyr2 as syr2;
-    pub use self::cblas_dspmv as spmv;
-    pub use self::cblas_dgbmv as gbmv;
-    pub use self::cblas_dsbmv as sbmv;
     pub use self::cblas_dtbmv as tbmv;
     pub use self::cblas_dtbsv as tbsv;
     pub use self::cblas_dtpmv as tpmv;
     pub use self::cblas_dtpsv as tpsv;
-    pub use self::cblas_dspr as spr;
-    pub use self::cblas_dspr2 as spr2;
+    pub use self::cblas_dtrmv as trmv;
+    pub use self::cblas_dtrsv as trsv;
 
-    extern {
-        pub fn cblas_dgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
-        pub fn cblas_dsymv(order: Order, sym: Symmetry, n: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
-        pub fn cblas_dtrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  lda: u32, x: *mut c_double,  inc_x: u32);
-        pub fn cblas_dtrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  lda: u32, x: *mut c_double,  inc_x: u32);
-        pub fn cblas_dger (order: Order, m: u32, n: u32, alpha: c_double,       x: *const c_double,  inc_x: u32, y: *const c_double,  inc_y: u32, a: *mut c_double,  lda: u32);
-        pub fn cblas_dsyr(order: Order, sym: Symmetry, n: u32, alpha: c_double,  x: *const c_double,  inc_x: u32, a: *mut c_double,  lda: u32);
-        pub fn cblas_dsyr2(order: Order, sym: Symmetry, n: u32, alpha: c_double,       x: *const c_double,  inc_x: u32, y: *const c_double,  inc_y: u32, a: *mut c_double,  lda: u32);
-        pub fn cblas_dspmv(order: Order, sym: Symmetry, n: u32, alpha: c_double,       a: *const c_double,  x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
-        pub fn cblas_dgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
-        pub fn cblas_dsbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: c_double,       a: *const c_double,  lda: u32, x: *const c_double,  inc_x: u32, beta: c_double,       y: *mut c_double,  inc_y: u32);
-        pub fn cblas_dtbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
-        pub fn cblas_dtbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
-        pub fn cblas_dtpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
-        pub fn cblas_dtpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_double,  x: *mut c_double,  inc_x: u32);
-        pub fn cblas_dspr(order: Order, sym: Symmetry, n: u32, alpha: c_double,  x: *const c_double,  inc_x: u32, a: *mut c_double);
-        pub fn cblas_dspr2(order: Order, sym: Symmetry, n: u32, alpha: c_double,       x: *const c_double,  inc_x: u32, y: *const c_double,  inc_y: u32, a: *mut c_double);
+    extern "C" {
+        pub fn cblas_dgemv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            x: *const c_double,
+            inc_x: u32,
+            beta: c_double,
+            y: *mut c_double,
+            inc_y: u32,
+        );
+        pub fn cblas_dsymv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            x: *const c_double,
+            inc_x: u32,
+            beta: c_double,
+            y: *mut c_double,
+            inc_y: u32,
+        );
+        pub fn cblas_dtrmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_double,
+            lda: u32,
+            x: *mut c_double,
+            inc_x: u32,
+        );
+        pub fn cblas_dtrsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_double,
+            lda: u32,
+            x: *mut c_double,
+            inc_x: u32,
+        );
+        pub fn cblas_dger(
+            order: Order,
+            m: u32,
+            n: u32,
+            alpha: c_double,
+            x: *const c_double,
+            inc_x: u32,
+            y: *const c_double,
+            inc_y: u32,
+            a: *mut c_double,
+            lda: u32,
+        );
+        pub fn cblas_dsyr(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            x: *const c_double,
+            inc_x: u32,
+            a: *mut c_double,
+            lda: u32,
+        );
+        pub fn cblas_dsyr2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            x: *const c_double,
+            inc_x: u32,
+            y: *const c_double,
+            inc_y: u32,
+            a: *mut c_double,
+            lda: u32,
+        );
+        pub fn cblas_dspmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            a: *const c_double,
+            x: *const c_double,
+            inc_x: u32,
+            beta: c_double,
+            y: *mut c_double,
+            inc_y: u32,
+        );
+        pub fn cblas_dgbmv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            kl: u32,
+            ku: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            x: *const c_double,
+            inc_x: u32,
+            beta: c_double,
+            y: *mut c_double,
+            inc_y: u32,
+        );
+        pub fn cblas_dsbmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            k: u32,
+            alpha: c_double,
+            a: *const c_double,
+            lda: u32,
+            x: *const c_double,
+            inc_x: u32,
+            beta: c_double,
+            y: *mut c_double,
+            inc_y: u32,
+        );
+        pub fn cblas_dtbmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_double,
+            x: *mut c_double,
+            inc_x: u32,
+        );
+        pub fn cblas_dtbsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_double,
+            x: *mut c_double,
+            inc_x: u32,
+        );
+        pub fn cblas_dtpmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_double,
+            x: *mut c_double,
+            inc_x: u32,
+        );
+        pub fn cblas_dtpsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_double,
+            x: *mut c_double,
+            inc_x: u32,
+        );
+        pub fn cblas_dspr(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            x: *const c_double,
+            inc_x: u32,
+            a: *mut c_double,
+        );
+        pub fn cblas_dspr2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            x: *const c_double,
+            inc_x: u32,
+            y: *const c_double,
+            inc_y: u32,
+            a: *mut c_double,
+        );
     }
 }
 
 pub mod cblas_c {
+    use attribute::{Diagonal, Order, Symmetry, Transpose};
     use libc::{c_float, c_void};
-    use attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-    };
 
+    pub use self::cblas_cgbmv as gbmv;
     pub use self::cblas_cgemv as gemv;
-    pub use self::cblas_csymv as symv;
-    pub use self::cblas_chemv as hemv;
-    pub use self::cblas_ctrmv as trmv;
-    pub use self::cblas_ctrsv as trsv;
-    pub use self::cblas_cgeru as geru;
     pub use self::cblas_cgerc as gerc;
+    pub use self::cblas_cgeru as geru;
+    pub use self::cblas_chbmv as hbmv;
+    pub use self::cblas_chemv as hemv;
     pub use self::cblas_cher as her;
     pub use self::cblas_cher2 as her2;
-    pub use self::cblas_cgbmv as gbmv;
-    pub use self::cblas_chbmv as hbmv;
-    pub use self::cblas_ctbmv as tbmv;
-    pub use self::cblas_ctbsv as tbsv;
     pub use self::cblas_chpmv as hpmv;
-    pub use self::cblas_ctpmv as tpmv;
-    pub use self::cblas_ctpsv as tpsv;
     pub use self::cblas_chpr as hpr;
     pub use self::cblas_chpr2 as hpr2;
+    pub use self::cblas_csymv as symv;
+    pub use self::cblas_ctbmv as tbmv;
+    pub use self::cblas_ctbsv as tbsv;
+    pub use self::cblas_ctpmv as tpmv;
+    pub use self::cblas_ctpsv as tpsv;
+    pub use self::cblas_ctrmv as trmv;
+    pub use self::cblas_ctrsv as trsv;
 
-    extern {
-        pub fn cblas_cgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_csymv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_chemv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_ctrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
-        pub fn cblas_ctrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
-        pub fn cblas_cgeru(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_cgerc(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_cher(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_void,   inc_x: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_cher2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_cgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_chbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_ctbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_ctbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_chpmv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_ctpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_ctpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_chpr(order: Order, sym: Symmetry, n: u32, alpha: c_float,  x: *const c_void,   inc_x: u32, a: *mut c_void);
-        pub fn cblas_chpr2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void);
+    extern "C" {
+        pub fn cblas_cgemv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_csymv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_chemv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_ctrmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            lda: u32,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_ctrsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            lda: u32,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_cgeru(
+            order: Order,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_cgerc(
+            order: Order,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_cher(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            x: *const c_void,
+            inc_x: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_cher2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_cgbmv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            kl: u32,
+            ku: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_chbmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_ctbmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_ctbsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_chpmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_ctpmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_ctpsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_chpr(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_float,
+            x: *const c_void,
+            inc_x: u32,
+            a: *mut c_void,
+        );
+        pub fn cblas_chpr2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+        );
     }
 }
 
 pub mod cblas_z {
+    use attribute::{Diagonal, Order, Symmetry, Transpose};
     use libc::{c_double, c_void};
-    use attribute::{
-        Order,
-        Transpose,
-        Symmetry,
-        Diagonal,
-    };
 
+    pub use self::cblas_zgbmv as gbmv;
     pub use self::cblas_zgemv as gemv;
-    pub use self::cblas_zsymv as symv;
-    pub use self::cblas_zhemv as hemv;
-    pub use self::cblas_ztrmv as trmv;
-    pub use self::cblas_ztrsv as trsv;
-    pub use self::cblas_zgeru as geru;
     pub use self::cblas_zgerc as gerc;
+    pub use self::cblas_zgeru as geru;
+    pub use self::cblas_zhbmv as hbmv;
+    pub use self::cblas_zhemv as hemv;
     pub use self::cblas_zher as her;
     pub use self::cblas_zher2 as her2;
-    pub use self::cblas_zgbmv as gbmv;
-    pub use self::cblas_zhbmv as hbmv;
-    pub use self::cblas_ztbmv as tbmv;
-    pub use self::cblas_ztbsv as tbsv;
     pub use self::cblas_zhpmv as hpmv;
-    pub use self::cblas_ztpmv as tpmv;
-    pub use self::cblas_ztpsv as tpsv;
     pub use self::cblas_zhpr as hpr;
     pub use self::cblas_zhpr2 as hpr2;
+    pub use self::cblas_zsymv as symv;
+    pub use self::cblas_ztbmv as tbmv;
+    pub use self::cblas_ztbsv as tbsv;
+    pub use self::cblas_ztpmv as tpmv;
+    pub use self::cblas_ztpsv as tpsv;
+    pub use self::cblas_ztrmv as trmv;
+    pub use self::cblas_ztrsv as trsv;
 
-    extern {
-        pub fn cblas_zgemv(order: Order, trans: Transpose, m: u32, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_zsymv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_zhemv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_ztrmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
-        pub fn cblas_ztrsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   lda: u32, x: *mut c_void,   inc_x: u32);
-        pub fn cblas_zgeru(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_zgerc(order: Order, m: u32, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_zher(order: Order, sym: Symmetry, n: u32, alpha: c_double, x: *const c_void,   inc_x: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_zher2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void,   lda: u32);
-        pub fn cblas_zgbmv(order: Order, trans: Transpose, m: u32, n: u32, kl: u32, ku: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_zhbmv(order: Order, sym: Symmetry, n: u32, k: u32, alpha: *const c_void, a: *const c_void,   lda: u32, x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_ztbmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_ztbsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, k: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_zhpmv(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, a: *const c_void,   x: *const c_void,   inc_x: u32, beta: *const c_void, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_ztpmv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_ztpsv(order: Order, sym: Symmetry, trans: Transpose, diag: Diagonal, n: u32, a: *const c_void,   x: *mut c_void,   inc_x: u32);
-        pub fn cblas_zhpr(order: Order, sym: Symmetry, n: u32, alpha: c_double, x: *const c_void,   inc_x: u32, a: *mut c_void);
-        pub fn cblas_zhpr2(order: Order, sym: Symmetry, n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *const c_void,   inc_y: u32, a: *mut c_void);
+    extern "C" {
+        pub fn cblas_zgemv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_zsymv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_zhemv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_ztrmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            lda: u32,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_ztrsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            lda: u32,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_zgeru(
+            order: Order,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_zgerc(
+            order: Order,
+            m: u32,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_zher(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            x: *const c_void,
+            inc_x: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_zher2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+            lda: u32,
+        );
+        pub fn cblas_zgbmv(
+            order: Order,
+            trans: Transpose,
+            m: u32,
+            n: u32,
+            kl: u32,
+            ku: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_zhbmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            k: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            lda: u32,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_ztbmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_ztbsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            k: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_zhpmv(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            a: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            beta: *const c_void,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_ztpmv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_ztpsv(
+            order: Order,
+            sym: Symmetry,
+            trans: Transpose,
+            diag: Diagonal,
+            n: u32,
+            a: *const c_void,
+            x: *mut c_void,
+            inc_x: u32,
+        );
+        pub fn cblas_zhpr(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: c_double,
+            x: *const c_void,
+            inc_x: u32,
+            a: *mut c_void,
+        );
+        pub fn cblas_zhpr2(
+            order: Order,
+            sym: Symmetry,
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            a: *mut c_void,
+        );
     }
 }

--- a/src/matrix_vector/ops.rs
+++ b/src/matrix_vector/ops.rs
@@ -4,10 +4,10 @@
 
 //! Wrappers for matrix-vector functions.
 
-use num::complex::{Complex, Complex32, Complex64};
 use attribute::{Diagonal, Symmetry, Transpose};
 use matrix::{BandMatrix, Matrix};
 use matrix_vector::ll::*;
+use num::complex::{Complex, Complex32, Complex64};
 use pointer::CPtr;
 use scalar::Scalar;
 use vector::Vector;
@@ -16,7 +16,14 @@ use vector::Vector;
 ///
 /// A ← αA<sup>OP</sup>x + βy
 pub trait Gemv: Sized {
-    fn gemv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(trans: Transpose, alpha: &Self, a: &dyn Matrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn gemv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        trans: Transpose,
+        alpha: &Self,
+        a: &dyn Matrix<Self>,
+        x: &V,
+        beta: &Self,
+        y: &mut W,
+    );
 }
 
 macro_rules! gemv_impl(($($t: ident), +) => (
@@ -59,10 +66,7 @@ mod gemv_tests {
 
     #[test]
     fn non_square() {
-        let a = M(2, 3,
-                 vec![
-                 1.0, -3.0, 1.0,
-                 2.0, -6.0, 2.0]);
+        let a = M(2, 3, vec![1.0, -3.0, 1.0, 2.0, -6.0, 2.0]);
         let x = vec![2.0, 1.0, 1.0];
         let mut y = vec![1.0, 2.0];
         let t = Transpose::NoTrans;
@@ -73,11 +77,7 @@ mod gemv_tests {
 
     #[test]
     fn transpose() {
-        let a = M(3, 2,
-                 vec![
-                     1.0, 2.0,
-                     -3.0, -6.0,
-                     1.0, 2.0]);
+        let a = M(3, 2, vec![1.0, 2.0, -3.0, -6.0, 1.0, 2.0]);
 
         let x = vec![2.0, 1.0, 1.0];
         let mut y = vec![1.0, 2.0];
@@ -93,14 +93,28 @@ mod gemv_tests {
 ///
 /// A ← αAx + βy
 pub trait Symv: Sized {
-    fn symv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &dyn Matrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn symv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        a: &dyn Matrix<Self>,
+        x: &V,
+        beta: &Self,
+        y: &mut W,
+    );
 }
 
 /// Hermitian multiply with vector
 ///
 /// A ← αAx + βy
 pub trait Hemv: Sized {
-    fn hemv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &dyn Matrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn hemv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        a: &dyn Matrix<Self>,
+        x: &V,
+        beta: &Self,
+        y: &mut W,
+    );
 }
 
 macro_rules! symv_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
@@ -171,14 +185,24 @@ mod symv_tests {
 ///
 /// A ← A + αxy<sup>T</sup>
 pub trait Ger: Sized {
-    fn ger<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(alpha: &Self, x: &V, y: &W, a: &mut dyn Matrix<Self>);
+    fn ger<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        alpha: &Self,
+        x: &V,
+        y: &W,
+        a: &mut dyn Matrix<Self>,
+    );
 }
 
 /// General rank-1 update (using hermitian conjugate)
 ///
 /// A ← A + αxy<sup>H</sup>
 pub trait Gerc: Ger {
-    fn gerc<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(alpha: &Self, x: &V, y: &W, a: &mut dyn Matrix<Self>) {
+    fn gerc<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        alpha: &Self,
+        x: &V,
+        y: &W,
+        a: &mut dyn Matrix<Self>,
+    ) {
         Ger::ger(alpha, x, y, a);
     }
 }
@@ -200,8 +224,8 @@ macro_rules! ger_impl(
     );
 );
 
-ger_impl!(Ger, ger, f32,       cblas_s::ger);
-ger_impl!(Ger, ger, f64,       cblas_d::ger);
+ger_impl!(Ger, ger, f32, cblas_s::ger);
+ger_impl!(Ger, ger, f64, cblas_d::ger);
 ger_impl!(Ger, ger, Complex32, cblas_c::geru);
 ger_impl!(Ger, ger, Complex64, cblas_z::geru);
 
@@ -212,9 +236,9 @@ ger_impl!(Gerc, gerc, Complex64, cblas_z::gerc);
 
 #[cfg(test)]
 mod ger_tests {
-    use std::iter::repeat;
     use matrix::tests::M;
     use matrix_vector::ops::Ger;
+    use std::iter::repeat;
 
     #[test]
     fn real() {
@@ -233,14 +257,24 @@ mod ger_tests {
 ///
 /// A ← A + αxx<sup>T</sup>
 pub trait Syr: Sized {
-    fn syr<V: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, a: &mut dyn Matrix<Self>);
+    fn syr<V: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        x: &V,
+        a: &mut dyn Matrix<Self>,
+    );
 }
 
 /// Hermitian rank-1 update
 ///
 /// A ← A + αxx<sup>H</sup>
 pub trait Her: Sized {
-    fn her<V: ?Sized + Vector<Complex<Self>>>(symmetry: Symmetry, alpha: &Self, x: &V, a: &mut dyn Matrix<Complex<Self>>);
+    fn her<V: ?Sized + Vector<Complex<Self>>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        x: &V,
+        a: &mut dyn Matrix<Complex<Self>>,
+    );
 }
 
 macro_rules! her_impl(($($t: ident), +) => (
@@ -283,14 +317,26 @@ syr_impl!(f32, f64);
 ///
 /// A ← A + αxy<sup>T</sup> + αyx<sup>T</sup>
 pub trait Syr2: Sized {
-    fn syr2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, y: &W, a: &mut dyn Matrix<Self>);
+    fn syr2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        x: &V,
+        y: &W,
+        a: &mut dyn Matrix<Self>,
+    );
 }
 
 /// Hermitian rank-2 update
 ///
 /// A ← A + αxy<sup>H</sup> + y(αx)<sup>H</sup>
 pub trait Her2: Sized {
-    fn her2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, y: &W, a: &mut dyn Matrix<Self>);
+    fn her2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        x: &V,
+        y: &W,
+        a: &mut dyn Matrix<Self>,
+    );
 }
 
 macro_rules! syr2_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
@@ -317,7 +363,14 @@ syr2_impl!(Her2, her2, Complex32, Complex64);
 ///
 /// A ← αA<sup>OP</sup>x + βy
 pub trait Gbmv: Sized {
-    fn gbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(trans: Transpose, alpha: &Self, a: &dyn BandMatrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn gbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        trans: Transpose,
+        alpha: &Self,
+        a: &dyn BandMatrix<Self>,
+        x: &V,
+        beta: &Self,
+        y: &mut W,
+    );
 }
 
 macro_rules! gbmv_impl(($($t: ident), +) => (
@@ -345,14 +398,28 @@ gbmv_impl!(f32, f64, Complex32, Complex64);
 ///
 /// A ← αAx + βy
 pub trait Sbmv: Sized {
-    fn sbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &dyn BandMatrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn sbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        a: &dyn BandMatrix<Self>,
+        x: &V,
+        beta: &Self,
+        y: &mut W,
+    );
 }
 
 /// Hermitian band matrix multiply with vector
 ///
 /// A ← αAx + βy
 pub trait Hbmv: Sized {
-    fn hbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &dyn BandMatrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn hbmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        a: &dyn BandMatrix<Self>,
+        x: &V,
+        beta: &Self,
+        y: &mut W,
+    );
 }
 
 macro_rules! sbmv_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
@@ -380,14 +447,26 @@ sbmv_impl!(Hbmv, hbmv, Complex32, Complex64);
 ///
 /// A ← A<sup>OP</sup>x
 pub trait Tbmv: Sized {
-    fn tbmv<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &dyn BandMatrix<Self>, x: &mut V);
+    fn tbmv<V: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        trans: Transpose,
+        diagonal: Diagonal,
+        a: &dyn BandMatrix<Self>,
+        x: &mut V,
+    );
 }
 
 /// Solve triangular band matrix system
 ///
 /// A ← A<sup>-1 OP</sup>x
 pub trait Tbsv: Sized {
-    fn tbsv<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &dyn BandMatrix<Self>, x: &mut V);
+    fn tbsv<V: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        trans: Transpose,
+        diagonal: Diagonal,
+        a: &dyn BandMatrix<Self>,
+        x: &mut V,
+    );
 }
 
 macro_rules! tbmv_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
@@ -413,14 +492,28 @@ tbmv_impl!(Tbsv, tbsv, f32, f64, Complex32, Complex64);
 ///
 /// A ← αAx + βy
 pub trait Spmv: Sized {
-    fn spmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &dyn Matrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn spmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        a: &dyn Matrix<Self>,
+        x: &V,
+        beta: &Self,
+        y: &mut W,
+    );
 }
 
 /// Hermitian packed matrix multiply with vector
 ///
 /// A ← αAx + βy
 pub trait Hpmv: Sized {
-    fn hpmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, a: &dyn Matrix<Self>, x: &V, beta: &Self, y: &mut W);
+    fn hpmv<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        a: &dyn Matrix<Self>,
+        x: &V,
+        beta: &Self,
+        y: &mut W,
+    );
 }
 
 macro_rules! spmv_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
@@ -448,14 +541,26 @@ spmv_impl!(Hpmv, hpmv, Complex32, Complex64);
 ///
 /// A ← A<sup>OP</sup>x
 pub trait Tpmv: Sized {
-    fn tpmv<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &dyn Matrix<Self>, x: &mut V);
+    fn tpmv<V: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        trans: Transpose,
+        diagonal: Diagonal,
+        a: &dyn Matrix<Self>,
+        x: &mut V,
+    );
 }
 
 /// Solve triangular packed matrix system
 ///
 /// A ← A<sup>-1 OP</sup>x
 pub trait Tpsv: Sized {
-    fn tpsv<V: ?Sized + Vector<Self>>(symmetry: Symmetry, trans: Transpose, diagonal: Diagonal, a: &dyn Matrix<Self>, x: &mut V);
+    fn tpsv<V: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        trans: Transpose,
+        diagonal: Diagonal,
+        a: &dyn Matrix<Self>,
+        x: &mut V,
+    );
 }
 
 macro_rules! tpmv_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (
@@ -481,7 +586,12 @@ tpmv_impl!(Tpsv, tpsv, f32, f64, Complex32, Complex64);
 ///
 /// A ← A + αxx<sup>H</sup>
 pub trait Hpr: Sized {
-    fn hpr<V: ?Sized + Vector<Complex<Self>>>(symmetry: Symmetry, alpha: &Self, x: &V, a: &mut dyn Matrix<Complex<Self>>);
+    fn hpr<V: ?Sized + Vector<Complex<Self>>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        x: &V,
+        a: &mut dyn Matrix<Complex<Self>>,
+    );
 }
 
 macro_rules! hpr_impl(($($t: ident), +) => (
@@ -506,7 +616,12 @@ hpr_impl!(f32, f64);
 ///
 /// A ← A + αxx<sup>T</sup>
 pub trait Spr: Sized {
-    fn spr<V: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, a: &mut dyn Matrix<Self>);
+    fn spr<V: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        x: &V,
+        a: &mut dyn Matrix<Self>,
+    );
 }
 
 macro_rules! spr_impl(($($t: ident), +) => (
@@ -531,14 +646,26 @@ spr_impl!(f32, f64);
 ///
 /// A ← A + αxy<sup>T</sup> + αyx<sup>T</sup>
 pub trait Spr2: Sized {
-    fn spr2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, y: &W, a: &mut dyn Matrix<Self>);
+    fn spr2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        x: &V,
+        y: &W,
+        a: &mut dyn Matrix<Self>,
+    );
 }
 
 /// Hermitian packed matrix rank-2 update
 ///
 /// A ← A + αxy<sup>H</sup> + y(αx)<sup>H</sup>
 pub trait Hpr2: Sized {
-    fn hpr2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(symmetry: Symmetry, alpha: &Self, x: &V, y: &W, a: &mut dyn Matrix<Self>);
+    fn hpr2<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        symmetry: Symmetry,
+        alpha: &Self,
+        x: &V,
+        y: &W,
+        a: &mut dyn Matrix<Self>,
+    );
 }
 
 macro_rules! spr2_impl(($trait_name: ident, $fn_name: ident, $($t: ident), +) => (

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 use num::complex::{Complex32, Complex64};
-use libc::{c_double, c_int, c_float, c_long, c_void};
+use libc::{c_double, c_float, c_long, c_void};
 
 pub trait CPtr<T> {
     fn as_c_ptr(self) -> T;
@@ -27,7 +27,7 @@ macro_rules! c_ptr_impl(
     );
 );
 
-c_ptr_impl!(i32, c_int);
+c_ptr_impl!(i32, u32);
 c_ptr_impl!(i64, c_long);
 c_ptr_impl!(f32, c_float);
 c_ptr_impl!(f64, c_double);

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use num::complex::{Complex32, Complex64};
 use libc::{c_double, c_float, c_long, c_void};
+use num::complex::{Complex32, Complex64};
 
 pub trait CPtr<T> {
     fn as_c_ptr(self) -> T;

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use num::complex::Complex;
 use libc::{c_double, c_float, c_void};
+use num::complex::Complex;
 
 pub trait Scalar<T, S> {
     fn as_const(self) -> T;

--- a/src/vector/ll.rs
+++ b/src/vector/ll.rs
@@ -5,7 +5,7 @@
 //! Bindings for vector functions.
 
 pub mod cblas_s {
-    use libc::{c_float, c_int, c_void};
+    use libc::{c_float, c_void};
 
     pub use self::cblas_scopy as copy;
     pub use self::cblas_saxpy as axpy;
@@ -23,25 +23,25 @@ pub mod cblas_s {
     pub use self::cblas_srotmg as rotmg;
 
     extern {
-        pub fn cblas_scopy(n: c_int, x: *const c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int);
-        pub fn cblas_saxpy(n: c_int, alpha: c_float,       x: *const c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int);
-        pub fn cblas_sscal(n: c_int, alpha: c_float,       x: *mut c_float,  inc_x: c_int);
-        pub fn cblas_sswap(n: c_int, x: *mut c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int);
-        pub fn cblas_sdsdot(n: c_int, alpha: c_float, x: *const c_float, inc_x: c_int, y: *const c_float, inc_y: c_int) -> c_float;
-        pub fn cblas_sdot(n: c_int, x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int) -> c_float;
-        pub fn cblas_sasum(n: c_int, x: *const c_float,  inc_x: c_int) -> c_float;
-        pub fn cblas_scasum(n: c_int, x: *const c_void,   inc_x: c_int) -> c_float;
-        pub fn cblas_snrm2(n: c_int, x: *const c_float,  inc_x: c_int) -> c_float;
-        pub fn cblas_scnrm2(n: c_int, x: *const c_void,   inc_x: c_int) -> c_float;
-        pub fn cblas_srot(n: c_int, x: *mut c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int, c: c_float,  s: c_float);
-        pub fn cblas_srotm(n: c_int, x: *mut c_float,  inc_x: c_int, y: *mut c_float,  inc_y: c_int, p: *const c_float);
+        pub fn cblas_scopy(n: u32, x: *const c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32);
+        pub fn cblas_saxpy(n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32);
+        pub fn cblas_sscal(n: u32, alpha: c_float,       x: *mut c_float,  inc_x: u32);
+        pub fn cblas_sswap(n: u32, x: *mut c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32);
+        pub fn cblas_sdsdot(n: u32, alpha: c_float, x: *const c_float, inc_x: u32, y: *const c_float, inc_y: u32) -> c_float;
+        pub fn cblas_sdot(n: u32, x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32) -> c_float;
+        pub fn cblas_sasum(n: u32, x: *const c_float,  inc_x: u32) -> c_float;
+        pub fn cblas_scasum(n: u32, x: *const c_void,   inc_x: u32) -> c_float;
+        pub fn cblas_snrm2(n: u32, x: *const c_float,  inc_x: u32) -> c_float;
+        pub fn cblas_scnrm2(n: u32, x: *const c_void,   inc_x: u32) -> c_float;
+        pub fn cblas_srot(n: u32, x: *mut c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32, c: c_float,  s: c_float);
+        pub fn cblas_srotm(n: u32, x: *mut c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32, p: *const c_float);
         pub fn cblas_srotg(a: *mut c_float,  b: *mut c_float,  c: *mut c_float,  s: *mut c_float);
         pub fn cblas_srotmg(d1: *mut c_float,  d2: *mut c_float,  b1: *mut c_float,  b2: c_float,  p: *mut c_float);
     }
 }
 
 pub mod cblas_d {
-    use libc::{c_double, c_float, c_int, c_void};
+    use libc::{c_double, c_float, c_void};
 
     pub use self::cblas_dcopy as copy;
     pub use self::cblas_daxpy as axpy;
@@ -59,25 +59,25 @@ pub mod cblas_d {
     pub use self::cblas_drotmg as rotmg;
 
     extern {
-        pub fn cblas_dcopy(n: c_int, x: *const c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int);
-        pub fn cblas_daxpy(n: c_int, alpha: c_double,      x: *const c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int);
-        pub fn cblas_dscal (n: c_int, alpha: c_double,      x: *mut c_double, inc_x: c_int);
-        pub fn cblas_dswap(n: c_int, x: *mut c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int);
-        pub fn cblas_dsdot(n: c_int, x: *const c_float,  inc_x: c_int, y: *const c_float,  inc_y: c_int) -> c_double;
-        pub fn cblas_ddot (n: c_int, x: *const c_double, inc_x: c_int, y: *const c_double, inc_y: c_int) -> c_double;
-        pub fn cblas_dasum (n: c_int, x: *const c_double, inc_x: c_int) -> c_double;
-        pub fn cblas_dzasum(n: c_int, x: *const c_void,   inc_x: c_int) -> c_double;
-        pub fn cblas_dnrm2 (n: c_int, x: *const c_double, inc_x: c_int) -> c_double;
-        pub fn cblas_dznrm2(n: c_int, x: *const c_void,   inc_x: c_int) -> c_double;
-        pub fn cblas_drot(n: c_int, x: *mut c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int, c: c_double, s: c_double);
-        pub fn cblas_drotm(n: c_int, x: *mut c_double, inc_x: c_int, y: *mut c_double, inc_y: c_int, p: *const c_double);
+        pub fn cblas_dcopy(n: u32, x: *const c_double, inc_x: u32, y: *mut c_double, inc_y: u32);
+        pub fn cblas_daxpy(n: u32, alpha: c_double,      x: *const c_double, inc_x: u32, y: *mut c_double, inc_y: u32);
+        pub fn cblas_dscal (n: u32, alpha: c_double,      x: *mut c_double, inc_x: u32);
+        pub fn cblas_dswap(n: u32, x: *mut c_double, inc_x: u32, y: *mut c_double, inc_y: u32);
+        pub fn cblas_dsdot(n: u32, x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32) -> c_double;
+        pub fn cblas_ddot (n: u32, x: *const c_double, inc_x: u32, y: *const c_double, inc_y: u32) -> c_double;
+        pub fn cblas_dasum (n: u32, x: *const c_double, inc_x: u32) -> c_double;
+        pub fn cblas_dzasum(n: u32, x: *const c_void,   inc_x: u32) -> c_double;
+        pub fn cblas_dnrm2 (n: u32, x: *const c_double, inc_x: u32) -> c_double;
+        pub fn cblas_dznrm2(n: u32, x: *const c_void,   inc_x: u32) -> c_double;
+        pub fn cblas_drot(n: u32, x: *mut c_double, inc_x: u32, y: *mut c_double, inc_y: u32, c: c_double, s: c_double);
+        pub fn cblas_drotm(n: u32, x: *mut c_double, inc_x: u32, y: *mut c_double, inc_y: u32, p: *const c_double);
         pub fn cblas_drotg(a: *mut c_double, b: *mut c_double, c: *mut c_double, s: *mut c_double);
         pub fn cblas_drotmg(d1: *mut c_double, d2: *mut c_double, b1: *mut c_double, b2: c_double, p: *mut c_double);
     }
 }
 
 pub mod cblas_c {
-    use libc::{c_float, c_int, c_void};
+    use libc::{c_float, c_void};
 
     pub use self::cblas_ccopy as copy;
     pub use self::cblas_caxpy as axpy;
@@ -88,18 +88,18 @@ pub mod cblas_c {
     pub use self::cblas_cdotc_sub as dotc_sub;
 
     extern {
-        pub fn cblas_ccopy(n: c_int, x: *const c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_caxpy(n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_cscal (n: c_int, alpha: *const c_void, x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_csscal(n: c_int, alpha: c_float,       x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_cswap(n: c_int, x: *mut c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_cdotu_sub(n: c_int, x: *const c_void, inc_x: c_int, y: *const c_void, inc_y: c_int, dotu: *mut c_void);
-        pub fn cblas_cdotc_sub(n: c_int, x: *const c_void, inc_x: c_int, y: *const c_void, inc_y: c_int, dotc: *mut c_void);
+        pub fn cblas_ccopy(n: u32, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_caxpy(n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_cscal (n: u32, alpha: *const c_void, x: *mut c_void,   inc_x: u32);
+        pub fn cblas_csscal(n: u32, alpha: c_float,       x: *mut c_void,   inc_x: u32);
+        pub fn cblas_cswap(n: u32, x: *mut c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_cdotu_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotu: *mut c_void);
+        pub fn cblas_cdotc_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotc: *mut c_void);
     }
 }
 
 pub mod cblas_z {
-    use libc::{c_double, c_int, c_void};
+    use libc::{c_double, c_void};
 
     pub use self::cblas_zcopy as copy;
     pub use self::cblas_zaxpy as axpy;
@@ -110,18 +110,18 @@ pub mod cblas_z {
     pub use self::cblas_zdotc_sub as dotc_sub;
 
     extern {
-        pub fn cblas_zcopy(n: c_int, x: *const c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_zaxpy(n: c_int, alpha: *const c_void, x: *const c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_zscal (n: c_int, alpha: *const c_void, x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_zdscal(n: c_int, alpha: c_double,      x: *mut c_void,   inc_x: c_int);
-        pub fn cblas_zswap(n: c_int, x: *mut c_void,   inc_x: c_int, y: *mut c_void,   inc_y: c_int);
-        pub fn cblas_zdotu_sub(n: c_int, x: *const c_void, inc_x: c_int, y: *const c_void, inc_y: c_int, dotu: *mut c_void);
-        pub fn cblas_zdotc_sub(n: c_int, x: *const c_void, inc_x: c_int, y: *const c_void, inc_y: c_int, dotc: *mut c_void);
+        pub fn cblas_zcopy(n: u32, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_zaxpy(n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_zscal (n: u32, alpha: *const c_void, x: *mut c_void,   inc_x: u32);
+        pub fn cblas_zdscal(n: u32, alpha: c_double,      x: *mut c_void,   inc_x: u32);
+        pub fn cblas_zswap(n: u32, x: *mut c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
+        pub fn cblas_zdotu_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotu: *mut c_void);
+        pub fn cblas_zdotc_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotc: *mut c_void);
     }
 }
 
 pub mod cblas_i {
-    use libc::{c_double, c_float, c_int, c_void, size_t};
+    use libc::{c_double, c_float, c_void, size_t};
 
     pub use self::cblas_isamax as samax;
     pub use self::cblas_idamax as damax;
@@ -129,9 +129,9 @@ pub mod cblas_i {
     pub use self::cblas_izamax as zamax;
 
     extern {
-        pub fn cblas_isamax(n: c_int, x: *const c_float,  inc_x: c_int) -> size_t;
-        pub fn cblas_idamax(n: c_int, x: *const c_double, inc_x: c_int) -> size_t;
-        pub fn cblas_icamax(n: c_int, x: *const c_void,   inc_x: c_int) -> size_t;
-        pub fn cblas_izamax(n: c_int, x: *const c_void,   inc_x: c_int) -> size_t;
+        pub fn cblas_isamax(n: u32, x: *const c_float,  inc_x: u32) -> size_t;
+        pub fn cblas_idamax(n: u32, x: *const c_double, inc_x: u32) -> size_t;
+        pub fn cblas_icamax(n: u32, x: *const c_void,   inc_x: u32) -> size_t;
+        pub fn cblas_izamax(n: u32, x: *const c_void,   inc_x: u32) -> size_t;
     }
 }

--- a/src/vector/ll.rs
+++ b/src/vector/ll.rs
@@ -7,131 +7,254 @@
 pub mod cblas_s {
     use libc::{c_float, c_void};
 
-    pub use self::cblas_scopy as copy;
+    pub use self::cblas_sasum as asum;
     pub use self::cblas_saxpy as axpy;
+    pub use self::cblas_scasum as casum;
+    pub use self::cblas_scnrm2 as cnrm2;
+    pub use self::cblas_scopy as copy;
+    pub use self::cblas_sdot as dot;
+    pub use self::cblas_sdsdot as dsdot;
+    pub use self::cblas_snrm2 as nrm2;
+    pub use self::cblas_srot as rot;
+    pub use self::cblas_srotg as rotg;
+    pub use self::cblas_srotm as rotm;
+    pub use self::cblas_srotmg as rotmg;
     pub use self::cblas_sscal as scal;
     pub use self::cblas_sswap as swap;
-    pub use self::cblas_sdsdot as dsdot;
-    pub use self::cblas_sdot as dot;
-    pub use self::cblas_sasum as asum;
-    pub use self::cblas_scasum as casum;
-    pub use self::cblas_snrm2 as nrm2;
-    pub use self::cblas_scnrm2 as cnrm2;
-    pub use self::cblas_srot as rot;
-    pub use self::cblas_srotm as rotm;
-    pub use self::cblas_srotg as rotg;
-    pub use self::cblas_srotmg as rotmg;
 
-    extern {
-        pub fn cblas_scopy(n: u32, x: *const c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32);
-        pub fn cblas_saxpy(n: u32, alpha: c_float,       x: *const c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32);
-        pub fn cblas_sscal(n: u32, alpha: c_float,       x: *mut c_float,  inc_x: u32);
-        pub fn cblas_sswap(n: u32, x: *mut c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32);
-        pub fn cblas_sdsdot(n: u32, alpha: c_float, x: *const c_float, inc_x: u32, y: *const c_float, inc_y: u32) -> c_float;
-        pub fn cblas_sdot(n: u32, x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32) -> c_float;
-        pub fn cblas_sasum(n: u32, x: *const c_float,  inc_x: u32) -> c_float;
-        pub fn cblas_scasum(n: u32, x: *const c_void,   inc_x: u32) -> c_float;
-        pub fn cblas_snrm2(n: u32, x: *const c_float,  inc_x: u32) -> c_float;
-        pub fn cblas_scnrm2(n: u32, x: *const c_void,   inc_x: u32) -> c_float;
-        pub fn cblas_srot(n: u32, x: *mut c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32, c: c_float,  s: c_float);
-        pub fn cblas_srotm(n: u32, x: *mut c_float,  inc_x: u32, y: *mut c_float,  inc_y: u32, p: *const c_float);
-        pub fn cblas_srotg(a: *mut c_float,  b: *mut c_float,  c: *mut c_float,  s: *mut c_float);
-        pub fn cblas_srotmg(d1: *mut c_float,  d2: *mut c_float,  b1: *mut c_float,  b2: c_float,  p: *mut c_float);
+    extern "C" {
+        pub fn cblas_scopy(n: u32, x: *const c_float, inc_x: u32, y: *mut c_float, inc_y: u32);
+        pub fn cblas_saxpy(
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            y: *mut c_float,
+            inc_y: u32,
+        );
+        pub fn cblas_sscal(n: u32, alpha: c_float, x: *mut c_float, inc_x: u32);
+        pub fn cblas_sswap(n: u32, x: *mut c_float, inc_x: u32, y: *mut c_float, inc_y: u32);
+        pub fn cblas_sdsdot(
+            n: u32,
+            alpha: c_float,
+            x: *const c_float,
+            inc_x: u32,
+            y: *const c_float,
+            inc_y: u32,
+        ) -> c_float;
+        pub fn cblas_sdot(
+            n: u32,
+            x: *const c_float,
+            inc_x: u32,
+            y: *const c_float,
+            inc_y: u32,
+        ) -> c_float;
+        pub fn cblas_sasum(n: u32, x: *const c_float, inc_x: u32) -> c_float;
+        pub fn cblas_scasum(n: u32, x: *const c_void, inc_x: u32) -> c_float;
+        pub fn cblas_snrm2(n: u32, x: *const c_float, inc_x: u32) -> c_float;
+        pub fn cblas_scnrm2(n: u32, x: *const c_void, inc_x: u32) -> c_float;
+        pub fn cblas_srot(
+            n: u32,
+            x: *mut c_float,
+            inc_x: u32,
+            y: *mut c_float,
+            inc_y: u32,
+            c: c_float,
+            s: c_float,
+        );
+        pub fn cblas_srotm(
+            n: u32,
+            x: *mut c_float,
+            inc_x: u32,
+            y: *mut c_float,
+            inc_y: u32,
+            p: *const c_float,
+        );
+        pub fn cblas_srotg(a: *mut c_float, b: *mut c_float, c: *mut c_float, s: *mut c_float);
+        pub fn cblas_srotmg(
+            d1: *mut c_float,
+            d2: *mut c_float,
+            b1: *mut c_float,
+            b2: c_float,
+            p: *mut c_float,
+        );
     }
 }
 
 pub mod cblas_d {
     use libc::{c_double, c_float, c_void};
 
-    pub use self::cblas_dcopy as copy;
-    pub use self::cblas_daxpy as axpy;
-    pub use self::cblas_dscal as scal;
-    pub use self::cblas_dswap as swap;
-    pub use self::cblas_dsdot as dsdot;
-    pub use self::cblas_ddot as dot;
     pub use self::cblas_dasum as asum;
-    pub use self::cblas_dzasum as zasum;
+    pub use self::cblas_daxpy as axpy;
+    pub use self::cblas_dcopy as copy;
+    pub use self::cblas_ddot as dot;
     pub use self::cblas_dnrm2 as nrm2;
-    pub use self::cblas_dznrm2 as znrm2;
     pub use self::cblas_drot as rot;
-    pub use self::cblas_drotm as rotm;
     pub use self::cblas_drotg as rotg;
+    pub use self::cblas_drotm as rotm;
     pub use self::cblas_drotmg as rotmg;
+    pub use self::cblas_dscal as scal;
+    pub use self::cblas_dsdot as dsdot;
+    pub use self::cblas_dswap as swap;
+    pub use self::cblas_dzasum as zasum;
+    pub use self::cblas_dznrm2 as znrm2;
 
-    extern {
+    extern "C" {
         pub fn cblas_dcopy(n: u32, x: *const c_double, inc_x: u32, y: *mut c_double, inc_y: u32);
-        pub fn cblas_daxpy(n: u32, alpha: c_double,      x: *const c_double, inc_x: u32, y: *mut c_double, inc_y: u32);
-        pub fn cblas_dscal (n: u32, alpha: c_double,      x: *mut c_double, inc_x: u32);
+        pub fn cblas_daxpy(
+            n: u32,
+            alpha: c_double,
+            x: *const c_double,
+            inc_x: u32,
+            y: *mut c_double,
+            inc_y: u32,
+        );
+        pub fn cblas_dscal(n: u32, alpha: c_double, x: *mut c_double, inc_x: u32);
         pub fn cblas_dswap(n: u32, x: *mut c_double, inc_x: u32, y: *mut c_double, inc_y: u32);
-        pub fn cblas_dsdot(n: u32, x: *const c_float,  inc_x: u32, y: *const c_float,  inc_y: u32) -> c_double;
-        pub fn cblas_ddot (n: u32, x: *const c_double, inc_x: u32, y: *const c_double, inc_y: u32) -> c_double;
-        pub fn cblas_dasum (n: u32, x: *const c_double, inc_x: u32) -> c_double;
-        pub fn cblas_dzasum(n: u32, x: *const c_void,   inc_x: u32) -> c_double;
-        pub fn cblas_dnrm2 (n: u32, x: *const c_double, inc_x: u32) -> c_double;
-        pub fn cblas_dznrm2(n: u32, x: *const c_void,   inc_x: u32) -> c_double;
-        pub fn cblas_drot(n: u32, x: *mut c_double, inc_x: u32, y: *mut c_double, inc_y: u32, c: c_double, s: c_double);
-        pub fn cblas_drotm(n: u32, x: *mut c_double, inc_x: u32, y: *mut c_double, inc_y: u32, p: *const c_double);
+        pub fn cblas_dsdot(
+            n: u32,
+            x: *const c_float,
+            inc_x: u32,
+            y: *const c_float,
+            inc_y: u32,
+        ) -> c_double;
+        pub fn cblas_ddot(
+            n: u32,
+            x: *const c_double,
+            inc_x: u32,
+            y: *const c_double,
+            inc_y: u32,
+        ) -> c_double;
+        pub fn cblas_dasum(n: u32, x: *const c_double, inc_x: u32) -> c_double;
+        pub fn cblas_dzasum(n: u32, x: *const c_void, inc_x: u32) -> c_double;
+        pub fn cblas_dnrm2(n: u32, x: *const c_double, inc_x: u32) -> c_double;
+        pub fn cblas_dznrm2(n: u32, x: *const c_void, inc_x: u32) -> c_double;
+        pub fn cblas_drot(
+            n: u32,
+            x: *mut c_double,
+            inc_x: u32,
+            y: *mut c_double,
+            inc_y: u32,
+            c: c_double,
+            s: c_double,
+        );
+        pub fn cblas_drotm(
+            n: u32,
+            x: *mut c_double,
+            inc_x: u32,
+            y: *mut c_double,
+            inc_y: u32,
+            p: *const c_double,
+        );
         pub fn cblas_drotg(a: *mut c_double, b: *mut c_double, c: *mut c_double, s: *mut c_double);
-        pub fn cblas_drotmg(d1: *mut c_double, d2: *mut c_double, b1: *mut c_double, b2: c_double, p: *mut c_double);
+        pub fn cblas_drotmg(
+            d1: *mut c_double,
+            d2: *mut c_double,
+            b1: *mut c_double,
+            b2: c_double,
+            p: *mut c_double,
+        );
     }
 }
 
 pub mod cblas_c {
     use libc::{c_float, c_void};
 
-    pub use self::cblas_ccopy as copy;
     pub use self::cblas_caxpy as axpy;
+    pub use self::cblas_ccopy as copy;
+    pub use self::cblas_cdotc_sub as dotc_sub;
+    pub use self::cblas_cdotu_sub as dotu_sub;
     pub use self::cblas_cscal as scal;
     pub use self::cblas_csscal as sscal;
     pub use self::cblas_cswap as swap;
-    pub use self::cblas_cdotu_sub as dotu_sub;
-    pub use self::cblas_cdotc_sub as dotc_sub;
 
-    extern {
-        pub fn cblas_ccopy(n: u32, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_caxpy(n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_cscal (n: u32, alpha: *const c_void, x: *mut c_void,   inc_x: u32);
-        pub fn cblas_csscal(n: u32, alpha: c_float,       x: *mut c_void,   inc_x: u32);
-        pub fn cblas_cswap(n: u32, x: *mut c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_cdotu_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotu: *mut c_void);
-        pub fn cblas_cdotc_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotc: *mut c_void);
+    extern "C" {
+        pub fn cblas_ccopy(n: u32, x: *const c_void, inc_x: u32, y: *mut c_void, inc_y: u32);
+        pub fn cblas_caxpy(
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_cscal(n: u32, alpha: *const c_void, x: *mut c_void, inc_x: u32);
+        pub fn cblas_csscal(n: u32, alpha: c_float, x: *mut c_void, inc_x: u32);
+        pub fn cblas_cswap(n: u32, x: *mut c_void, inc_x: u32, y: *mut c_void, inc_y: u32);
+        pub fn cblas_cdotu_sub(
+            n: u32,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            dotu: *mut c_void,
+        );
+        pub fn cblas_cdotc_sub(
+            n: u32,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            dotc: *mut c_void,
+        );
     }
 }
 
 pub mod cblas_z {
     use libc::{c_double, c_void};
 
-    pub use self::cblas_zcopy as copy;
     pub use self::cblas_zaxpy as axpy;
-    pub use self::cblas_zscal as scal;
-    pub use self::cblas_zdscal as dscal;
-    pub use self::cblas_zswap as swap;
-    pub use self::cblas_zdotu_sub as dotu_sub;
+    pub use self::cblas_zcopy as copy;
     pub use self::cblas_zdotc_sub as dotc_sub;
+    pub use self::cblas_zdotu_sub as dotu_sub;
+    pub use self::cblas_zdscal as dscal;
+    pub use self::cblas_zscal as scal;
+    pub use self::cblas_zswap as swap;
 
-    extern {
-        pub fn cblas_zcopy(n: u32, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_zaxpy(n: u32, alpha: *const c_void, x: *const c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_zscal (n: u32, alpha: *const c_void, x: *mut c_void,   inc_x: u32);
-        pub fn cblas_zdscal(n: u32, alpha: c_double,      x: *mut c_void,   inc_x: u32);
-        pub fn cblas_zswap(n: u32, x: *mut c_void,   inc_x: u32, y: *mut c_void,   inc_y: u32);
-        pub fn cblas_zdotu_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotu: *mut c_void);
-        pub fn cblas_zdotc_sub(n: u32, x: *const c_void, inc_x: u32, y: *const c_void, inc_y: u32, dotc: *mut c_void);
+    extern "C" {
+        pub fn cblas_zcopy(n: u32, x: *const c_void, inc_x: u32, y: *mut c_void, inc_y: u32);
+        pub fn cblas_zaxpy(
+            n: u32,
+            alpha: *const c_void,
+            x: *const c_void,
+            inc_x: u32,
+            y: *mut c_void,
+            inc_y: u32,
+        );
+        pub fn cblas_zscal(n: u32, alpha: *const c_void, x: *mut c_void, inc_x: u32);
+        pub fn cblas_zdscal(n: u32, alpha: c_double, x: *mut c_void, inc_x: u32);
+        pub fn cblas_zswap(n: u32, x: *mut c_void, inc_x: u32, y: *mut c_void, inc_y: u32);
+        pub fn cblas_zdotu_sub(
+            n: u32,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            dotu: *mut c_void,
+        );
+        pub fn cblas_zdotc_sub(
+            n: u32,
+            x: *const c_void,
+            inc_x: u32,
+            y: *const c_void,
+            inc_y: u32,
+            dotc: *mut c_void,
+        );
     }
 }
 
 pub mod cblas_i {
     use libc::{c_double, c_float, c_void, size_t};
 
-    pub use self::cblas_isamax as samax;
-    pub use self::cblas_idamax as damax;
     pub use self::cblas_icamax as camax;
+    pub use self::cblas_idamax as damax;
+    pub use self::cblas_isamax as samax;
     pub use self::cblas_izamax as zamax;
 
-    extern {
-        pub fn cblas_isamax(n: u32, x: *const c_float,  inc_x: u32) -> size_t;
+    extern "C" {
+        pub fn cblas_isamax(n: u32, x: *const c_float, inc_x: u32) -> size_t;
         pub fn cblas_idamax(n: u32, x: *const c_double, inc_x: u32) -> size_t;
-        pub fn cblas_icamax(n: u32, x: *const c_void,   inc_x: u32) -> size_t;
-        pub fn cblas_izamax(n: u32, x: *const c_void,   inc_x: u32) -> size_t;
+        pub fn cblas_icamax(n: u32, x: *const c_void, inc_x: u32) -> size_t;
+        pub fn cblas_izamax(n: u32, x: *const c_void, inc_x: u32) -> size_t;
     }
 }

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //! Vector operations.
-use libc::c_int;
 use num::traits::NumCast;
 use num::complex::{Complex32, Complex64};
 use vector::ops::{Copy, Axpy, Scal, Dot, Nrm2, Asum, Iamax};
@@ -15,9 +14,9 @@ pub mod ops;
 pub trait Vector<T> {
     /// The stride within the vector. For example, if `inc` returns 7, every
     /// 7th element is used. Defaults to 1.
-    fn inc(&self) -> c_int { 1 }
+    fn inc(&self) -> u32 { 1 }
     /// The number of elements in the vector.
-    fn len(&self) -> c_int;
+    fn len(&self) -> u32;
     /// An unsafe pointer to a contiguous block of memory.
     fn as_ptr(&self) -> *const T;
     /// An unsafe mutable pointer to a contiguous block of memory.
@@ -77,8 +76,8 @@ pub trait VectorOperations<T>: Sized + Vector<T>
 impl<T> Vector<T> for Vec<T> {
 
     #[inline]
-    fn len(&self) -> c_int {
-        let l: Option<c_int> = NumCast::from(Vec::len(self));
+    fn len(&self) -> u32 {
+        let l: Option<u32> = NumCast::from(Vec::len(self));
         match l {
             Some(l) => l,
             None => panic!(),
@@ -95,8 +94,8 @@ impl<T> Vector<T> for Vec<T> {
 impl<T> Vector<T> for [T] {
 
     #[inline]
-    fn len(&self) -> c_int {
-        let l: Option<c_int> = NumCast::from(<[T]>::len(self));
+    fn len(&self) -> u32 {
+        let l: Option<u32> = NumCast::from(<[T]>::len(self));
         match l {
             Some(l) => l,
             None => panic!(),

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -3,9 +3,9 @@
 // license that can be found in the LICENSE file.
 
 //! Vector operations.
-use num::traits::NumCast;
 use num::complex::{Complex32, Complex64};
-use vector::ops::{Copy, Axpy, Scal, Dot, Nrm2, Asum, Iamax};
+use num::traits::NumCast;
+use vector::ops::{Asum, Axpy, Copy, Dot, Iamax, Nrm2, Scal};
 
 pub mod ll;
 pub mod ops;
@@ -14,7 +14,9 @@ pub mod ops;
 pub trait Vector<T> {
     /// The stride within the vector. For example, if `inc` returns 7, every
     /// 7th element is used. Defaults to 1.
-    fn inc(&self) -> u32 { 1 }
+    fn inc(&self) -> u32 {
+        1
+    }
     /// The number of elements in the vector.
     fn len(&self) -> u32;
     /// An unsafe pointer to a contiguous block of memory.
@@ -24,13 +26,16 @@ pub trait Vector<T> {
 }
 
 impl<'a, T> Into<Vec<T>> for &'a dyn Vector<T>
-    where T: Copy {
-
+where
+    T: Copy,
+{
     fn into(self) -> Vec<T> {
         let n = self.len() as usize;
 
         let mut x = Vec::with_capacity(n);
-        unsafe { x.set_len(n); }
+        unsafe {
+            x.set_len(n);
+        }
         Copy::copy(self, &mut x);
 
         x
@@ -38,8 +43,9 @@ impl<'a, T> Into<Vec<T>> for &'a dyn Vector<T>
 }
 
 pub trait VectorOperations<T>: Sized + Vector<T>
-    where T: Copy + Axpy + Scal + Dot + Nrm2 + Asum + Iamax {
-
+where
+    T: Copy + Axpy + Scal + Dot + Nrm2 + Asum + Iamax,
+{
     #[inline]
     fn update(&mut self, alpha: &T, x: &dyn Vector<T>) -> &mut Self {
         Axpy::axpy(alpha, x, self);
@@ -74,7 +80,6 @@ pub trait VectorOperations<T>: Sized + Vector<T>
 }
 
 impl<T> Vector<T> for Vec<T> {
-
     #[inline]
     fn len(&self) -> u32 {
         let l: Option<u32> = NumCast::from(Vec::len(self));
@@ -85,14 +90,17 @@ impl<T> Vector<T> for Vec<T> {
     }
 
     #[inline]
-    fn as_ptr(&self) -> *const T { self[..].as_ptr() }
+    fn as_ptr(&self) -> *const T {
+        self[..].as_ptr()
+    }
 
     #[inline]
-    fn as_mut_ptr(&mut self) -> *mut T { (&mut self[..]).as_mut_ptr() }
+    fn as_mut_ptr(&mut self) -> *mut T {
+        (&mut self[..]).as_mut_ptr()
+    }
 }
 
 impl<T> Vector<T> for [T] {
-
     #[inline]
     fn len(&self) -> u32 {
         let l: Option<u32> = NumCast::from(<[T]>::len(self));
@@ -103,10 +111,14 @@ impl<T> Vector<T> for [T] {
     }
 
     #[inline]
-    fn as_ptr(&self) -> *const T { <[T]>::as_ptr(self) }
+    fn as_ptr(&self) -> *const T {
+        <[T]>::as_ptr(self)
+    }
 
     #[inline]
-    fn as_mut_ptr(&mut self) -> *mut T { <[T]>::as_mut_ptr(self) }
+    fn as_mut_ptr(&mut self) -> *mut T {
+        <[T]>::as_mut_ptr(self)
+    }
 }
 
 macro_rules! operations_impl(

--- a/src/vector/ops.rs
+++ b/src/vector/ops.rs
@@ -4,12 +4,12 @@
 
 //! Wrappers for vector functions.
 
-use num::complex::{Complex, Complex32, Complex64};
-use std::cmp;
 use default::Default;
+use matrix::Matrix;
+use num::complex::{Complex, Complex32, Complex64};
 use pointer::CPtr;
 use scalar::Scalar;
-use matrix::Matrix;
+use std::cmp;
 use vector::ll::*;
 use vector::Vector;
 
@@ -91,24 +91,24 @@ mod axpy_tests {
 
     #[test]
     fn real() {
-        let x = vec![1f32,-2f32,3f32,4f32];
-        let y = vec![3f32,7f32,-2f32,2f32];
+        let x = vec![1f32, -2f32, 3f32, 4f32];
+        let y = vec![3f32, 7f32, -2f32, 2f32];
         let mut z = y.clone();
 
         Axpy::axpy(&1f32, &y, &mut z);
         Axpy::axpy(&1f32, &x, &mut z);
-        assert_eq!(z, vec![7f32,12f32,-1f32,8f32]);
+        assert_eq!(z, vec![7f32, 12f32, -1f32, 8f32]);
     }
 
     #[test]
     fn slice() {
-        let x = vec![1f32,-2f32,3f32,4f32,5f32];
-        let y = vec![3f32,7f32,-2f32,2f32];
+        let x = vec![1f32, -2f32, 3f32, 4f32, 5f32];
+        let y = vec![3f32, 7f32, -2f32, 2f32];
         let mut z = y.clone();
 
         Axpy::axpy(&1f32, &y, &mut z);
         Axpy::axpy(&1f32, &x[..4], &mut z);
-        assert_eq!(z, vec![7f32,12f32,-1f32,8f32]);
+        assert_eq!(z, vec![7f32, 12f32, -1f32, 8f32]);
     }
 
     #[test]
@@ -120,7 +120,6 @@ mod axpy_tests {
         Axpy::axpy(&Complex::new(-1f32, 1f32), &y, &mut z);
         assert_eq!(z, vec![Complex::new(0f32, 6f32), Complex::new(-4f32, 2f32)]);
     }
-
 }
 
 /// Computes `a * x` and stores the result in `x`.
@@ -161,7 +160,7 @@ mod scal_tests {
 
     #[test]
     fn real() {
-        let mut x = vec![1f32,-2f32,3f32,4f32];
+        let mut x = vec![1f32, -2f32, 3f32, 4f32];
 
         Scal::scal(&-2f32, &mut x);
         assert_eq!(x, vec![-2f32, 4f32, -6f32, -8f32]);
@@ -169,7 +168,7 @@ mod scal_tests {
 
     #[test]
     fn slice() {
-        let mut x = vec![1f32,-2f32,3f32,4f32];
+        let mut x = vec![1f32, -2f32, 3f32, 4f32];
 
         Scal::scal(&-2f32, &mut x[..3]);
         assert_eq!(x, vec![-2f32, 4f32, -6f32, 4f32]);
@@ -190,7 +189,6 @@ mod scal_tests {
         Scal::scal(&Complex::new(2f32, 0f32), &mut x);
         assert_eq!(x, vec![Complex::new(2f32, 2f32), Complex::new(2f32, 6f32)]);
     }
-
 }
 
 /// Swaps the content of `x` and `y`.
@@ -224,11 +222,10 @@ mod swap_tests {
 
     #[test]
     fn real() {
-        let mut x = vec![1f32,-2f32,3f32,4f32];
-        let mut y = vec![2f32,-3f32,4f32,1f32];
+        let mut x = vec![1f32, -2f32, 3f32, 4f32];
+        let mut y = vec![2f32, -3f32, 4f32, 1f32];
         let xr = y.clone();
         let yr = x.clone();
-
 
         Swap::swap(&mut x, &mut y);
         assert_eq!(x, xr);
@@ -237,10 +234,10 @@ mod swap_tests {
 
     #[test]
     fn slice() {
-        let mut x = [1f32,-2f32,3f32,4f32];
-        let mut y = [2f32,-3f32,4f32,1f32];
-        let xr = [2f32,-3f32,4f32,1f32];
-        let yr = [1f32,-2f32,3f32,4f32];
+        let mut x = [1f32, -2f32, 3f32, 4f32];
+        let mut y = [2f32, -3f32, 4f32, 1f32];
+        let xr = [2f32, -3f32, 4f32, 1f32];
+        let yr = [1f32, -2f32, 3f32, 4f32];
 
         Swap::swap(&mut x[..], &mut y[..]);
         assert_eq!(x, xr);
@@ -258,7 +255,6 @@ mod swap_tests {
         assert_eq!(x, xr);
         assert_eq!(y, yr);
     }
-
 }
 
 /// Computes `x^T * y`.
@@ -313,8 +309,8 @@ mod dot_tests {
 
     #[test]
     fn real() {
-        let x = vec![1f32,-2f32,3f32,4f32];
-        let y = vec![1f32,1f32,1f32,1f32];
+        let x = vec![1f32, -2f32, 3f32, 4f32];
+        let y = vec![1f32, 1f32, 1f32, 1f32];
 
         let xr: f32 = Dot::dot(&x, &y);
         assert_eq!(xr, 6f32);
@@ -322,8 +318,8 @@ mod dot_tests {
 
     #[test]
     fn slice() {
-        let x = [1f32,-2f32,3f32,4f32];
-        let y = [1f32,1f32,1f32,1f32];
+        let x = [1f32, -2f32, 3f32, 4f32];
+        let y = [1f32, 1f32, 1f32, 1f32];
 
         let xr: f32 = Dot::dot(&x[..], &y[..]);
         assert_eq!(xr, 6f32);
@@ -337,7 +333,6 @@ mod dot_tests {
         let xr: Complex<f32> = Dot::dot(&x, &y);
         assert_eq!(xr, Complex::new(-2f32, 6f32));
     }
-
 }
 
 /// Computes `x^H * y`.
@@ -441,7 +436,7 @@ mod asum_tests {
 
     #[test]
     fn real() {
-        let x = vec![1f32,-2f32,3f32,4f32];
+        let x = vec![1f32, -2f32, 3f32, 4f32];
 
         let r: f32 = Asum::asum(&x);
         assert_eq!(r, 10f32);
@@ -449,7 +444,7 @@ mod asum_tests {
 
     #[test]
     fn slice() {
-        let x = [1f32,-2f32,3f32,4f32];
+        let x = [1f32, -2f32, 3f32, 4f32];
 
         let r: f32 = Asum::asum(&x[..]);
         assert_eq!(r, 10f32);
@@ -471,7 +466,7 @@ mod nrm2_tests {
 
     #[test]
     fn real() {
-        let x = vec![3f32,-4f32];
+        let x = vec![3f32, -4f32];
 
         let xr: f32 = Nrm2::nrm2(&x);
         assert_eq!(xr, 5f32);
@@ -479,7 +474,7 @@ mod nrm2_tests {
 
     #[test]
     fn slice() {
-        let x = [3f32,-4f32];
+        let x = [3f32, -4f32];
 
         let xr: f32 = Nrm2::nrm2(&x[..]);
         assert_eq!(xr, 5f32);
@@ -516,8 +511,8 @@ macro_rules! iamax_impl(
     );
 );
 
-iamax_impl!(f32,       cblas_i::samax);
-iamax_impl!(f64,       cblas_i::damax);
+iamax_impl!(f32, cblas_i::samax);
+iamax_impl!(f64, cblas_i::damax);
 iamax_impl!(Complex32, cblas_i::camax);
 iamax_impl!(Complex64, cblas_i::zamax);
 
@@ -528,7 +523,7 @@ mod iamax_tests {
 
     #[test]
     fn real() {
-        let x = vec![1f32,-2f32,3f32,4f32];
+        let x = vec![1f32, -2f32, 3f32, 4f32];
 
         let xr = Iamax::iamax(&x);
         assert_eq!(xr, 3usize);
@@ -536,7 +531,7 @@ mod iamax_tests {
 
     #[test]
     fn slice() {
-        let x = [1f32,-2f32,3f32,4f32];
+        let x = [1f32, -2f32, 3f32, 4f32];
 
         let xr = Iamax::iamax(&x[..]);
         assert_eq!(xr, 3usize);
@@ -555,7 +550,12 @@ mod iamax_tests {
 /// the value of the cosine of the angle in the Givens matrix, and `sin` is
 /// the sine.
 pub trait Rot: Sized {
-    fn rot<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(x: &mut V, y: &mut W, cos: &Self, sin: &Self);
+    fn rot<V: ?Sized + Vector<Self>, W: ?Sized + Vector<Self>>(
+        x: &mut V,
+        y: &mut W,
+        cos: &Self,
+        sin: &Self,
+    );
 }
 
 macro_rules! rot_impl(($($t: ident), +) => (
@@ -577,15 +577,12 @@ rot_impl!(f32, f64);
 
 #[cfg(test)]
 mod rot_tests {
-    use vector::ops::{
-        Scal,
-        Rot,
-    };
+    use vector::ops::{Rot, Scal};
 
     #[test]
     fn real() {
-        let mut x = vec![1f32,-2f32,3f32,4f32];
-        let mut y = vec![3f32,7f32,-2f32,2f32];
+        let mut x = vec![1f32, -2f32, 3f32, 4f32];
+        let mut y = vec![3f32, 7f32, -2f32, 2f32];
         let cos = 0f32;
         let sin = 1f32;
 


### PR DESCRIPTION
Got rid of usage of c_int throughout the project, replacing what was
essentially an alias for `i32` with `u32`.